### PR TITLE
Stop timer modal: recent notes dropdown

### DIFF
--- a/Models/php/time_tracking_api.php
+++ b/Models/php/time_tracking_api.php
@@ -215,6 +215,22 @@ try {
         ]);
     }
 
+    // ── get_recent_notes ──────────────────────────────────────────────────────
+    elseif ($action === 'get_recent_notes') {
+
+        $stmt = $pdo->query(
+            "SELECT notes
+             FROM time_entries
+             WHERE notes IS NOT NULL AND notes != ''
+             GROUP BY notes
+             ORDER BY MAX(start_time) DESC
+             LIMIT 20"
+        );
+        $notes = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+        sendJsonResponse(['success' => true, 'notes' => $notes]);
+    }
+
     // ── update_phase_number ───────────────────────────────────────────────────
     elseif ($action === 'update_phase_number') {
 

--- a/Projects/Professional/survey_projects.php
+++ b/Projects/Professional/survey_projects.php
@@ -2214,21 +2214,53 @@ function stopActiveTimer() {
     openStopTimerModal();
 }
 
-function openStopTimerModal() {
+async function openStopTimerModal() {
     if (!timerState.isRunning) return;
     document.getElementById('stopTimerModal').style.display = 'block';
+
+    // Fetch recent notes and populate dropdown
+    try {
+        const fd = new FormData();
+        fd.append('action', 'get_recent_notes');
+        const resp = await fetch(TIME_API, { method: 'POST', body: fd });
+        const data = await resp.json();
+        if (data.success && data.notes.length > 0) {
+            const select = document.getElementById('recentNotesSelect');
+            select.innerHTML = '<option value="">— Select a recent note —</option>';
+            data.notes.forEach(n => {
+                const opt = document.createElement('option');
+                opt.value = n;
+                opt.textContent = n.length > 70 ? n.slice(0, 70) + '…' : n;
+                select.appendChild(opt);
+            });
+            document.getElementById('recentNotesRow').style.display = 'block';
+        }
+    } catch (err) { /* silently skip — dropdown just won't show */ }
+
     setTimeout(() => document.getElementById('stopTimerNotes').focus(), 80);
+}
+
+function applyRecentNote() {
+    const select = document.getElementById('recentNotesSelect');
+    if (select.value) {
+        document.getElementById('stopTimerNotes').value = select.value;
+        select.value = '';
+    }
 }
 
 function cancelStopTimer() {
     document.getElementById('stopTimerModal').style.display = 'none';
     document.getElementById('stopTimerNotes').value = '';
+    document.getElementById('recentNotesRow').style.display = 'none';
+    document.getElementById('recentNotesSelect').innerHTML = '<option value="">— Select a recent note —</option>';
 }
 
 async function confirmStopTimer() {
     const notes = document.getElementById('stopTimerNotes').value.trim();
     document.getElementById('stopTimerModal').style.display = 'none';
     document.getElementById('stopTimerNotes').value = '';
+    document.getElementById('recentNotesRow').style.display = 'none';
+    document.getElementById('recentNotesSelect').innerHTML = '<option value="">— Select a recent note —</option>';
     await _doStopTimer(notes);
 }
 
@@ -2766,7 +2798,13 @@ function copyTimesheetForVantagepoint() {
                 <button class="close-button" onclick="cancelStopTimer()"><i class="fas fa-times"></i></button>
             </div>
             <div class="modal-body">
-                <p style="color:var(--gray-600);margin-bottom:0.75rem;font-size:0.9rem;">Add optional notes for this time entry:</p>
+                <div id="recentNotesRow" style="display:none;margin-bottom:0.85rem;">
+                    <label style="font-size:0.8rem;font-weight:600;color:var(--gray-500);display:block;margin-bottom:0.3rem;">Recent notes</label>
+                    <select id="recentNotesSelect" onchange="applyRecentNote()" style="width:100%;padding:0.5rem 0.75rem;border:1px solid #e2e8f0;border-radius:6px;font-size:0.875rem;color:#374151;background:#fff;box-sizing:border-box;">
+                        <option value="">— Select a recent note —</option>
+                    </select>
+                </div>
+                <label style="font-size:0.8rem;font-weight:600;color:var(--gray-500);display:block;margin-bottom:0.3rem;">Note</label>
                 <textarea id="stopTimerNotes" rows="3" style="width:100%;padding:0.6rem 0.75rem;border:1px solid #e2e8f0;border-radius:6px;font-size:0.875rem;resize:vertical;font-family:inherit;box-sizing:border-box;" placeholder="e.g. Completed boundary research, reviewed deeds..."></textarea>
             </div>
             <div class="modal-footer" style="display:flex;gap:0.75rem;justify-content:flex-end;padding:1rem 1.5rem;border-top:1px solid #f1f5f9;">


### PR DESCRIPTION
When the stop timer modal opens, it fetches the 20 most recently used distinct notes from time_entries (ordered by last use) and shows them in a dropdown above the textarea. Selecting an entry populates the textarea so users can reuse or edit an existing note. The dropdown is hidden when there are no prior notes. State is fully reset on cancel or confirm.

https://claude.ai/code/session_01K37s4VKrHXGwX1jxh2YK7Y