### PR TITLE
Scope recent notes dropdown to the current task

### DIFF
--- a/Models/php/time_tracking_api.php
+++ b/Models/php/time_tracking_api.php
@@ -218,14 +218,22 @@ try {
     // ── get_recent_notes ──────────────────────────────────────────────────────
     elseif ($action === 'get_recent_notes') {
 
-        $stmt = $pdo->query(
+        $taskId   = (int)($_POST['task_id']   ?? 0);
+        $taskName = trim($_POST['task_name'] ?? '');
+
+        // For real tasks filter by task_id; for admin/training (task_id=0)
+        // also require task_name so Admin and Training notes stay separate.
+        $stmt = $pdo->prepare(
             "SELECT notes
              FROM time_entries
              WHERE notes IS NOT NULL AND notes != ''
+               AND task_id = :task_id
+               AND (:task_id > 0 OR task_name = :task_name)
              GROUP BY notes
              ORDER BY MAX(start_time) DESC
              LIMIT 20"
         );
+        $stmt->execute([':task_id' => $taskId, ':task_name' => $taskName]);
         $notes = $stmt->fetchAll(PDO::FETCH_COLUMN);
 
         sendJsonResponse(['success' => true, 'notes' => $notes]);

--- a/Projects/Professional/survey_projects.php
+++ b/Projects/Professional/survey_projects.php
@@ -2221,7 +2221,9 @@ async function openStopTimerModal() {
     // Fetch recent notes and populate dropdown
     try {
         const fd = new FormData();
-        fd.append('action', 'get_recent_notes');
+        fd.append('action',    'get_recent_notes');
+        fd.append('task_id',   timerState.taskId   ?? 0);
+        fd.append('task_name', timerState.taskName ?? '');
         const resp = await fetch(TIME_API, { method: 'POST', body: fd });
         const data = await resp.json();
         if (data.success && data.notes.length > 0) {


### PR DESCRIPTION
get_recent_notes now filters by task_id so only notes previously logged against that specific task appear. For admin/training entries (task_id=0) task_name is also matched so Admin and Training notes stay separate. openStopTimerModal passes task_id and task_name from timerState.

https://claude.ai/code/session_01K37s4VKrHXGwX1jxh2YK7Y