### PR TITLE
Fix timesheet modal horizontal overflow — all 7 days now fit in modal

### DIFF
--- a/Models/css/survey_projects_notes.css
+++ b/Models/css/survey_projects_notes.css
@@ -2226,21 +2226,29 @@ body {
 .timesheet-table {
     width: 100%;
     border-collapse: collapse;
-    font-size: 0.8rem;
-    overflow-x: auto;
+    font-size: 0.78rem;
+    table-layout: fixed;
 }
+
+/* Column widths — must sum to ~100% so nothing overflows */
+.timesheet-table th:nth-child(1)                         { width: 13%; }   /* Project */
+.timesheet-table th:nth-child(2)                         { width: 5%;  }   /* Phase   */
+.timesheet-table th:nth-child(3)                         { width: 14%; }   /* Task    */
+.timesheet-table th:nth-child(n+4):nth-child(-n+10)      { width: 7%;  }   /* Mon–Sun */
+.timesheet-table th:nth-child(11)                        { width: 5%;  }   /* Total   */
+/* Notes col (12) gets the remaining ~14% automatically */
 
 .timesheet-table th {
     background: var(--gray-50);
-    padding: 0.6rem 0.75rem;
+    padding: 0.5rem 0.4rem;
     text-align: center;
     font-weight: 600;
     color: var(--gray-700);
     border: 1px solid var(--gray-200);
-    white-space: nowrap;
     position: sticky;
     top: 0;
     z-index: 2;
+    overflow: hidden;
 }
 
 .timesheet-table th:first-child,
@@ -2250,11 +2258,14 @@ body {
 }
 
 .timesheet-table td {
-    padding: 0.5rem 0.75rem;
+    padding: 0.4rem 0.4rem;
     border: 1px solid var(--gray-200);
     text-align: center;
     color: var(--gray-700);
     vertical-align: middle;
+    overflow: hidden;
+    word-break: break-word;
+    overflow-wrap: break-word;
 }
 
 .timesheet-table td:first-child,
@@ -2336,17 +2347,17 @@ td.today-cell {
     font-size: 0.9rem;
 }
 
-/* Scrollable table wrapper */
+/* Table wrapper — no horizontal scroll; table must fit the modal */
 .timesheet-table-wrapper {
     border-radius: var(--border-radius);
-    overflow-x: auto;
+    overflow: hidden;
     width: 100%;
 }
 
-/* Timesheet modal — sticky header, scrollable body */
+/* Timesheet modal — wide enough to hold all 7 day columns without scrolling */
 .timesheet-modal-content {
-    width: 95vw;
-    max-width: 960px;
+    width: min(1300px, 97vw);
+    max-width: min(1300px, 97vw);
     max-height: 90vh;
     overflow: hidden;
     display: flex;
@@ -2364,7 +2375,7 @@ td.today-cell {
 
 /* Day cells — split hours / note layout */
 .ts-day-cell {
-    min-width: 86px;
+    min-width: 0;
     vertical-align: middle;
     padding: 0 !important;
 }
@@ -2379,7 +2390,7 @@ td.today-cell {
     font-weight: 700;
     font-size: 0.88rem;
     color: var(--gray-800);
-    padding: 0.3rem 0.5rem;
+    padding: 0.25rem 0.3rem;
     text-align: center;
     cursor: pointer;
     transition: color 0.15s, background 0.15s;

--- a/Models/css/survey_projects_notes.css
+++ b/Models/css/survey_projects_notes.css
@@ -2521,3 +2521,262 @@ td.today-cell {
 
 .ts-note-actions button:first-child { color: var(--success-color); }
 .ts-note-actions button:last-child  { color: var(--gray-400); }
+
+/* ── Toast subtitle ───────────────────────────────────────────────────────────── */
+.toast-subtitle {
+    display: none;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--gray-600);
+    margin-top: 3px;
+}
+
+/* ── Project identity banner (inside expanded row) ───────────────────────────── */
+.project-identity-banner {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+    border: 1px solid #bfdbfe;
+    border-radius: var(--border-radius);
+    padding: 0.65rem 1rem;
+    margin-bottom: 1rem;
+}
+
+.project-identity-id {
+    font-family: 'Courier New', monospace;
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--primary-color);
+    white-space: nowrap;
+}
+
+.project-identity-name {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--gray-700);
+}
+
+/* ── Pin / "Add to Week" button ──────────────────────────────────────────────── */
+.btn-weekly-pin {
+    background: #f0fdf4;
+    color: #15803d;
+    border: 1px solid #bbf7d0;
+    transition: all 0.2s ease;
+}
+
+.btn-weekly-pin:hover {
+    background: #dcfce7;
+    border-color: #86efac;
+}
+
+.btn-weekly-pin.pinned {
+    background: #fef3c7;
+    color: #92400e;
+    border-color: #fcd34d;
+}
+
+.btn-weekly-pin.pinned:hover {
+    background: #fde68a;
+    border-color: #f59e0b;
+}
+
+/* ── Weekly view container ───────────────────────────────────────────────────── */
+.weekly-view {
+    padding: 1.5rem 2rem;
+}
+
+.weekly-view-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--gray-200);
+}
+
+.weekly-view-header h3 {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--gray-800);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.weekly-view-header p {
+    font-size: 0.875rem;
+    color: var(--gray-500);
+    margin-top: 0.25rem;
+}
+
+/* ── Weekly project cards grid ───────────────────────────────────────────────── */
+.weekly-projects-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+    gap: 1rem;
+}
+
+.weekly-card {
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+    transition: box-shadow 0.2s ease;
+}
+
+.weekly-card:hover {
+    box-shadow: var(--shadow-md);
+}
+
+.weekly-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.85rem 1rem;
+    background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+    border-bottom: 1px solid #bfdbfe;
+}
+
+.weekly-card-identity {
+    min-width: 0;
+}
+
+.weekly-card-id {
+    font-family: 'Courier New', monospace;
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.weekly-card-name {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--gray-800);
+    margin-top: 0.15rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.weekly-card-location {
+    font-size: 0.78rem;
+    color: var(--gray-500);
+    margin-top: 0.2rem;
+}
+
+.weekly-card-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.4rem;
+    flex-shrink: 0;
+}
+
+.weekly-remove-btn {
+    background: #fee2e2;
+    color: #dc2626;
+    border: 1px solid #fca5a5;
+    font-size: 0.75rem;
+    padding: 0.2rem 0.5rem;
+    white-space: nowrap;
+    transition: all 0.2s ease;
+}
+
+.weekly-remove-btn:hover {
+    background: #fecaca;
+    border-color: #f87171;
+}
+
+/* ── Weekly card links ───────────────────────────────────────────────────────── */
+.weekly-card-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    padding: 0.75rem 1rem;
+}
+
+.weekly-card-link {
+    display: flex;
+    align-items: stretch;
+    border: 1px solid var(--gray-200);
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.weekly-link-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.6rem;
+    background: var(--gray-50);
+    color: var(--gray-700);
+    text-decoration: none;
+    font-size: 0.8rem;
+    font-weight: 500;
+    transition: background 0.15s ease;
+}
+
+.weekly-link-btn:hover {
+    background: #eff6ff;
+    color: var(--primary-color);
+}
+
+.weekly-link-btn i {
+    font-size: 0.75rem;
+    color: var(--gray-500);
+}
+
+.weekly-copy-btn {
+    display: flex;
+    align-items: center;
+    padding: 0.3rem 0.45rem;
+    background: none;
+    border: none;
+    border-left: 1px solid var(--gray-200);
+    color: var(--gray-400);
+    cursor: pointer;
+    font-size: 0.75rem;
+    transition: all 0.15s ease;
+}
+
+.weekly-copy-btn:hover {
+    background: #eff6ff;
+    color: var(--primary-color);
+}
+
+.weekly-no-links {
+    color: var(--gray-400);
+    font-size: 0.875rem;
+    font-style: italic;
+}
+
+/* ── Weekly empty state ──────────────────────────────────────────────────────── */
+.weekly-empty-state {
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    padding: 4rem 2rem;
+    text-align: center;
+    color: var(--gray-500);
+}
+
+.weekly-empty-state i {
+    font-size: 3.5rem;
+    color: var(--gray-300);
+    margin-bottom: 1rem;
+}
+
+.weekly-empty-state h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--gray-700);
+    margin-bottom: 0.5rem;
+}
+
+.weekly-empty-state p {
+    font-size: 0.875rem;
+    max-width: 360px;
+}


### PR DESCRIPTION
- Widen modal to min(1300px, 97vw) so there is room for all columns
- table-layout: fixed so the table never exceeds its container width
- Declare explicit column widths via nth-child (Project 13%, Phase 5%,
  Task 14%, Mon–Sun 7% each, Total 5%, Notes gets the remainder)
- Remove min-width: 86px from .ts-day-cell (was forcing 602px min width)
- Change .timesheet-table-wrapper from overflow-x: auto to overflow: hidden
- Tighten th/td padding and hours-block padding to reclaim horizontal space
- Add word-break/overflow-wrap to td so long project/task names wrap in place

https://claude.ai/code/session_01ESeovn2NQWGwx6k5FHfrok