### PR TITLE
Add weekly projects tab, project identity banner, and timesheet project ID editing

### DIFF
--- a/Models/css/survey_projects_notes.css
+++ b/Models/css/survey_projects_notes.css
@@ -2780,3 +2780,27 @@ td.today-cell {
     font-size: 0.875rem;
     max-width: 360px;
 }
+
+/* ── Timesheet project cell inline edit ──────────────────────────────────────── */
+.ts-project-cell .ts-project-view {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    cursor: default;
+}
+
+.ts-project-edit-icon {
+    font-size: 0.6rem;
+    color: var(--gray-400);
+    opacity: 0;
+    transition: opacity 0.15s;
+    flex-shrink: 0;
+}
+
+.ts-project-cell:hover .ts-project-edit-icon {
+    opacity: 0.7;
+}
+
+.ts-project-cell:hover .ts-project-view {
+    cursor: pointer;
+}

--- a/Models/php/time_tracking_api.php
+++ b/Models/php/time_tracking_api.php
@@ -255,6 +255,63 @@ try {
         sendJsonResponse(['success' => true]);
     }
 
+    // ── update_entry_project ──────────────────────────────────────────────────
+    elseif ($action === 'update_entry_project') {
+
+        $taskId       = (int)($_POST['task_id']        ?? 0);
+        $taskName     = trim($_POST['task_name']       ?? '');
+        $weekStart    = trim($_POST['week_start']      ?? '');
+        $weekEnd      = trim($_POST['week_end']        ?? '');
+        $newProjectId = trim($_POST['new_project_id']  ?? '');
+
+        if (!$newProjectId) {
+            sendJsonResponse(['success' => false, 'message' => 'new_project_id is required']);
+        }
+
+        // Validate new project ID exists in survey_projects
+        $checkStmt = $pdo->prepare("SELECT project_name FROM survey_projects WHERE project_id = :pid LIMIT 1");
+        $checkStmt->execute([':pid' => $newProjectId]);
+        $proj = $checkStmt->fetch(PDO::FETCH_ASSOC);
+        if (!$proj) {
+            sendJsonResponse(['success' => false, 'message' => 'Project ID not found']);
+        }
+        $newProjectName = $proj['project_name'];
+
+        if ($taskId > 0) {
+            // Real task: update all entries for this task across all weeks
+            $stmt = $pdo->prepare(
+                "UPDATE time_entries
+                 SET project_id = :project_id, project_name = :project_name
+                 WHERE task_id = :task_id"
+            );
+            $stmt->execute([
+                ':project_id'   => $newProjectId,
+                ':project_name' => $newProjectName,
+                ':task_id'      => $taskId,
+            ]);
+        } else {
+            // Admin/training entry: scope to the current week and task_name
+            if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $weekStart) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $weekEnd)) {
+                sendJsonResponse(['success' => false, 'message' => 'week_start and week_end are required for non-task entries']);
+            }
+            $stmt = $pdo->prepare(
+                "UPDATE time_entries
+                 SET project_id = :project_id, project_name = :project_name
+                 WHERE task_id = 0 AND task_name = :task_name
+                   AND DATE(start_time) BETWEEN :week_start AND :week_end"
+            );
+            $stmt->execute([
+                ':project_id'   => $newProjectId,
+                ':project_name' => $newProjectName,
+                ':task_name'    => $taskName,
+                ':week_start'   => $weekStart,
+                ':week_end'     => $weekEnd,
+            ]);
+        }
+
+        sendJsonResponse(['success' => true, 'project_name' => $newProjectName]);
+    }
+
     // ── update_day_hours ──────────────────────────────────────────────────────
     elseif ($action === 'update_day_hours') {
 

--- a/Projects/Professional/survey_projects.php
+++ b/Projects/Professional/survey_projects.php
@@ -2610,6 +2610,68 @@ function tsCancelPhase(td) {
         </span>`;
 }
 
+// ── Project inline editing ─────────────────────────────────────────────────
+
+function tsEditProject(td) {
+    const current = td.dataset.projectId || '';
+    td.innerHTML = `
+        <div style="display:flex;align-items:center;gap:0.3rem;">
+            <input type="text" value="${esc(current)}" placeholder="Project ID"
+                style="width:90px;font-size:0.82rem;padding:2px 5px;border:1px solid var(--primary-color);border-radius:4px;outline:none;font-family:monospace;"
+                onkeydown="if(event.key==='Enter')tsSaveProject(this.closest('td'));if(event.key==='Escape')tsCancelProject(this.closest('td'));">
+            <button onclick="tsSaveProject(this.closest('td'))" title="Save" style="background:none;border:none;cursor:pointer;color:var(--success-color);font-size:0.8rem;padding:0 2px;"><i class="fas fa-check"></i></button>
+            <button onclick="tsCancelProject(this.closest('td'))" title="Cancel" style="background:none;border:none;cursor:pointer;color:var(--gray-400);font-size:0.8rem;padding:0 2px;"><i class="fas fa-times"></i></button>
+        </div>`;
+    const inp = td.querySelector('input');
+    inp.focus();
+    inp.select();
+}
+
+async function tsSaveProject(td) {
+    const taskId      = td.dataset.taskId    || '0';
+    const taskName    = td.dataset.taskName  || '';
+    const weekStart   = td.dataset.weekStart || '';
+    const weekEnd     = td.dataset.weekEnd   || '';
+    const input       = td.querySelector('input');
+    if (!input) return;
+    const newProjectId = input.value.trim();
+    if (!newProjectId) { showToast('Project ID cannot be empty', 'error'); return; }
+
+    try {
+        const fd = new FormData();
+        fd.append('action',         'update_entry_project');
+        fd.append('task_id',        taskId);
+        fd.append('task_name',      taskName);
+        fd.append('week_start',     weekStart);
+        fd.append('week_end',       weekEnd);
+        fd.append('new_project_id', newProjectId);
+        const resp = await fetch(TIME_API, { method: 'POST', body: fd });
+        const data = await resp.json();
+        if (!data.success) { showToast(data.message || 'Could not update project', 'error'); return; }
+        td.dataset.projectId   = newProjectId;
+        td.dataset.projectName = data.project_name || '';
+        showToast('Project updated', 'success');
+    } catch (err) {
+        showToast('Network error updating project', 'error');
+        return;
+    }
+    tsCancelProject(td);
+}
+
+function tsCancelProject(td) {
+    const projectId   = td.dataset.projectId   || '';
+    const projectName = td.dataset.projectName || '';
+    td.innerHTML = `
+        <div class="ts-project-view" ondblclick="tsEditProject(this.parentElement)" title="Double-click to edit project">
+            <span style="font-family:monospace;font-size:0.8rem;color:var(--primary-color);font-weight:600;">${esc(projectId)}</span>
+            <button onclick="event.stopPropagation();tsClipboard('${esc(projectId)}')" title="Copy project number"
+                style="background:none;border:none;cursor:pointer;padding:1px 3px;color:var(--gray-400);font-size:0.7rem;opacity:0.6;"
+                onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.6'"><i class="fas fa-copy"></i></button>
+            <i class="fas fa-pencil-alt ts-project-edit-icon"></i>
+        </div>
+        ${projectName ? `<span style="font-size:0.75rem;color:var(--gray-500);font-weight:400;">${esc(projectName)}</span>` : ''}`;
+}
+
 // ── Day-note inline editing ────────────────────────────────────────────────
 
 function tsEditDayNote(td) {
@@ -2748,6 +2810,8 @@ function renderTimesheetTable(entries, weekStart) {
         d.setDate(d.getDate() + i);
         return d;
     });
+    const weekStartStr = dates[0].toISOString().split('T')[0];
+    const weekEndStr   = dates[6].toISOString().split('T')[0];
 
     // Group entries by task (composite key handles admin/training where task_id=0)
     const taskMap = {};
@@ -2814,13 +2878,22 @@ function renderTimesheetTable(entries, weekStart) {
         const safeNotes   = esc(allNotes);
         const canEditPhase = t.task_id > 0;
 
-        // Project cell: project ID with copy button
-        const projectCell = `<td>
-            <div style="display:flex;align-items:center;gap:0.3rem;">
-                <span style="font-family:monospace;font-size:0.8rem;color:var(--primary-color);font-weight:600;">${esc(t.project_id)}</span>
-                <button onclick="tsClipboard('${esc(t.project_id)}')" title="Copy project number" style="background:none;border:none;cursor:pointer;padding:1px 3px;color:var(--gray-400);font-size:0.7rem;opacity:0.6;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.6'"><i class="fas fa-copy"></i></button>
+        // Project cell: project ID with copy + double-click to edit
+        const safeProjectId   = esc(t.project_id);
+        const safeProjectName = esc(t.project_name || '');
+        const projectCell = `<td class="ts-project-cell"
+            data-task-id="${t.task_id}"
+            data-task-name="${esc(t.task_name)}"
+            data-project-id="${safeProjectId}"
+            data-project-name="${safeProjectName}"
+            data-week-start="${weekStartStr}"
+            data-week-end="${weekEndStr}">
+            <div class="ts-project-view" ondblclick="tsEditProject(this.parentElement)" title="Double-click to edit project">
+                <span style="font-family:monospace;font-size:0.8rem;color:var(--primary-color);font-weight:600;">${safeProjectId}</span>
+                <button onclick="event.stopPropagation();tsClipboard('${safeProjectId}')" title="Copy project number" style="background:none;border:none;cursor:pointer;padding:1px 3px;color:var(--gray-400);font-size:0.7rem;opacity:0.6;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.6'"><i class="fas fa-copy"></i></button>
+                <i class="fas fa-pencil-alt ts-project-edit-icon"></i>
             </div>
-            ${t.project_name ? `<span style="font-size:0.75rem;color:var(--gray-500);font-weight:400;">${esc(t.project_name)}</span>` : ''}
+            ${t.project_name ? `<span style="font-size:0.75rem;color:var(--gray-500);font-weight:400;">${safeProjectName}</span>` : ''}
         </td>`;
 
         // Phase cell: editable for real tasks

--- a/Projects/Professional/survey_projects.php
+++ b/Projects/Professional/survey_projects.php
@@ -9,7 +9,7 @@ $currentUsername = $_SESSION['username'] ?? 'User';
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Survey Project Manager - Professional Dashboard</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js"></script>
-    <link rel="stylesheet" href="../../Models/css/survey_projects_notes.css">
+    <link rel="stylesheet" href="../../Models/css/survey_projects_notes.css?v=<?php echo filemtime(__DIR__ . '/../../Models/css/survey_projects_notes.css'); ?>">
 </head>
 <body>
 


### PR DESCRIPTION
## Summary

- **Weekly Projects tab** — new sidebar tab ("This Week") backed by a `weekly_projects` DB table; per-user (session-scoped) pin/unpin of projects so frequently-used ones are always one click away
- **Project identity banner** — expanded project rows now show the project ID and name at the top, and the copy-path toast shows a subtitle with the project ID · name to prevent copying the wrong project's path
- **Timesheet overflow fix** — weekly timesheet modal widened to `min(1300px, 97vw)` with `table-layout: fixed` and explicit column widths so all 7 days fit without horizontal scrolling
- **Double-click project ID editing** — project ID cell in the timesheet modal is now inline-editable on double-click; validates the new ID against `survey_projects` and updates all matching `time_entries` rows; admin/training entries (task_id=0) are scoped to the current week
- **CSS cache-busting** — CSS link uses `filemtime()` version query string so browser always picks up the latest styles after deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESeovn2NQWGwx6k5FHfrok)_