### PR TITLE
Add session heartbeat to prevent logout during idle survey_projects.php use

### DIFF
--- a/Models/php/session_heartbeat.php
+++ b/Models/php/session_heartbeat.php
@@ -1,0 +1,19 @@
+<?php
+// Keeps the PHP session alive while a page is open in the background —
+// Auth::isLoggedIn() both refreshes last_activity and writes to $_SESSION,
+// which resets the file's mtime so PHP's session GC won't reap it.
+error_reporting(0);
+ini_set('display_errors', 0);
+
+header('Content-Type: application/json');
+header('Cache-Control: no-cache, must-revalidate');
+
+require_once __DIR__ . '/../../classes/Auth.php';
+
+try {
+    $auth = new Auth();
+    $loggedIn = $auth->isLoggedIn();
+    echo json_encode(['success' => true, 'loggedIn' => $loggedIn]);
+} catch (Exception $e) {
+    echo json_encode(['success' => false, 'loggedIn' => false]);
+}

--- a/Projects/Professional/survey_projects.php
+++ b/Projects/Professional/survey_projects.php
@@ -671,6 +671,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Restore any active timer session
     checkActiveTimer();
+
+    // Keep the session alive while this page stays open
+    startSessionHeartbeat();
 });
 
 function loadProjects() {
@@ -2131,6 +2134,24 @@ document.addEventListener('click', function(event) {
 // TIME TRACKER — core logic
 // ═══════════════════════════════════════════════════════════════════════════
 const TIME_API = '../../Models/php/time_tracking_api.php';
+const HEARTBEAT_API = '../../Models/php/session_heartbeat.php';
+const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000; // 5 min — well under PHP's session GC window
+
+// Periodically ping the server so the PHP session doesn't expire while this
+// tab is left open (e.g. mid-survey with no clicks for 20-30+ minutes).
+function startSessionHeartbeat() {
+    setInterval(async () => {
+        try {
+            const resp = await fetch(HEARTBEAT_API, { method: 'POST' });
+            const data = await resp.json();
+            if (!data.loggedIn) {
+                showToast('Your session has expired. Please log in again.', 'error');
+            }
+        } catch (err) {
+            console.error('Session heartbeat error:', err);
+        }
+    }, HEARTBEAT_INTERVAL_MS);
+}
 
 // Parse start_time from API — handles both Unix timestamp (integer) and
 // MySQL datetime string (which Hostinger returns as UTC but without 'Z').


### PR DESCRIPTION
## Summary
- Users working in `survey_projects.php` were getting logged out after a period of inactivity, hitting "Not logged in" when trying to log time to a task.
- Root cause: nothing on the page talks to the server while a task timer just runs client-side (`setInterval` only), and `time_tracking_api.php` never refreshes session activity. PHP's own session garbage collection was reaping the session file since nothing wrote to `$_SESSION` to keep it fresh.
- Added `Models/php/session_heartbeat.php`, a lightweight endpoint that calls `Auth::isLoggedIn()` to refresh `last_activity` and touch the session, preventing GC from expiring it.
- Added a client-side heartbeat in `survey_projects.php` that pings this endpoint every 5 minutes while the page stays open, and shows a toast if the session has genuinely expired (e.g. account deactivated).

## Test plan
- [ ] Confirm `php -l` passes on both changed files
- [ ] Open `survey_projects.php`, leave it idle past the previous logout window (~20-30 min), then log time to a task and confirm no "Not logged in" error
- [ ] Verify the heartbeat toast appears if the session is invalidated server-side (e.g. manually expiring the session)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GqQxsWztdaM7B74DyWZSJm)_