### PR TITLE
Add personal project 00_004: grocery & meal planner

### DIFF
--- a/Models/css/grocery_meal.css
+++ b/Models/css/grocery_meal.css
@@ -1,0 +1,457 @@
+/* ============================================================
+   grocery_meal.css — Grocery & Meal Planner component styles
+   Requires: survey_projects_notes.css (base layout, .btn, .checklist-modal*,
+   .toast, .form-group/.form-label, etc.)
+   ============================================================ */
+
+.tab-panel {
+    display: none;
+    animation: gmTabFadeIn 0.2s ease;
+}
+
+.tab-panel.active {
+    display: block;
+}
+
+@keyframes gmTabFadeIn {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ---------- Filter Bar ---------- */
+.gm-filter-bar {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.gm-filter-bar select {
+    padding: 0.5rem 0.875rem;
+    border: 1px solid var(--gray-300);
+    border-radius: var(--border-radius);
+    font-size: 0.875rem;
+    background: var(--white);
+    color: var(--gray-700);
+}
+
+.gm-week-label {
+    font-weight: 600;
+    color: var(--gray-700);
+    font-size: 0.9rem;
+}
+
+/* ---------- Stat Cards ---------- */
+.gm-stat-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.gm-stat-card {
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow-sm);
+    padding: 1.25rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.gm-stat-card i {
+    font-size: 1.5rem;
+    color: var(--primary-color);
+}
+
+.gm-stat-card strong {
+    display: block;
+    font-size: 1.4rem;
+    color: var(--gray-900);
+}
+
+.gm-stat-card span {
+    font-size: 0.8rem;
+    color: var(--gray-500);
+}
+
+/* ---------- Generic Panel ---------- */
+.gm-panel {
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow-sm);
+    padding: 1.5rem 1.75rem;
+}
+
+.gm-panel h3 {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--gray-800);
+    margin-bottom: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.gm-hint {
+    color: var(--gray-500);
+    font-size: 0.825rem;
+    margin-bottom: 1rem;
+}
+
+.gm-hint-inline {
+    color: var(--gray-400);
+    font-size: 0.75rem;
+    font-weight: 400;
+}
+
+.gm-empty-inline {
+    color: var(--gray-500);
+    font-size: 0.875rem;
+}
+
+.gm-plan-summary-row {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid var(--gray-100);
+    font-size: 0.875rem;
+}
+
+.gm-plan-summary-row:last-child {
+    border-bottom: none;
+}
+
+.gm-plan-summary-row strong {
+    flex-shrink: 0;
+    width: 130px;
+    color: var(--gray-700);
+}
+
+/* ---------- Meal Card Grid ---------- */
+.gm-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.25rem;
+}
+
+.gm-card {
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--border-radius);
+    box-shadow: var(--shadow-sm);
+    padding: 1.125rem 1.25rem;
+}
+
+.gm-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 0.5rem;
+}
+
+.gm-card-actions {
+    display: flex;
+    gap: 0.375rem;
+}
+
+.gm-card-name {
+    font-weight: 700;
+    color: var(--gray-900);
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+}
+
+.gm-card-macros {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    font-size: 0.8rem;
+    color: var(--gray-500);
+    margin-bottom: 0.5rem;
+}
+
+.gm-card-macros i {
+    color: var(--warning-color);
+}
+
+.gm-tags {
+    display: flex;
+    gap: 0.375rem;
+    flex-wrap: wrap;
+}
+
+.gm-tag {
+    display: inline-flex;
+    padding: 0.15rem 0.5rem;
+    background: rgba(37, 99, 235, 0.08);
+    color: var(--primary-color);
+    border: 1px solid rgba(37, 99, 235, 0.2);
+    border-radius: 9999px;
+    font-size: 0.7rem;
+    font-weight: 600;
+}
+
+.gm-type-badge {
+    display: inline-flex;
+    padding: 0.2rem 0.625rem;
+    background: rgba(100, 116, 139, 0.1);
+    color: var(--gray-600);
+    border: 1px solid rgba(100, 116, 139, 0.25);
+    border-radius: 9999px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+/* ---------- Tables ---------- */
+.gm-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--border-radius);
+    overflow: hidden;
+    font-size: 0.875rem;
+}
+
+.gm-table th,
+.gm-table td {
+    padding: 0.7rem 0.9rem;
+    text-align: left;
+    border-bottom: 1px solid var(--gray-100);
+}
+
+.gm-table thead th {
+    background: var(--gray-50);
+    color: var(--gray-600);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.gm-table tfoot td {
+    background: var(--gray-50);
+    border-bottom: none;
+}
+
+.gm-table-actions {
+    display: flex;
+    gap: 0.375rem;
+    white-space: nowrap;
+}
+
+/* ---------- Ingredient rows (meal modal) ---------- */
+.gm-ingredient-row {
+    display: grid;
+    grid-template-columns: 2fr 0.8fr 0.8fr auto;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    align-items: center;
+}
+
+.gm-ingredient-row select,
+.gm-ingredient-row input {
+    padding: 0.45rem 0.6rem;
+    border: 1px solid var(--gray-300);
+    border-radius: 6px;
+    font-size: 0.825rem;
+}
+
+/* ---------- Price modal ---------- */
+.gm-price-latest {
+    margin-bottom: 1.25rem;
+}
+
+.gm-latest-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.75rem;
+}
+
+.gm-latest-card {
+    background: var(--gray-50);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--border-radius);
+    padding: 0.75rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.gm-latest-card strong {
+    color: var(--gray-700);
+    font-size: 0.8rem;
+}
+
+.gm-latest-card span {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--gray-900);
+}
+
+.gm-latest-card small {
+    color: var(--gray-400);
+    font-size: 0.7rem;
+}
+
+.gm-subhead {
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--gray-400);
+    margin: 1.25rem 0 0.6rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--gray-100);
+}
+
+.gm-inline-form {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    align-items: center;
+    margin-bottom: 0.75rem;
+}
+
+.gm-inline-form select,
+.gm-inline-form input {
+    padding: 0.45rem 0.6rem;
+    border: 1px solid var(--gray-300);
+    border-radius: 6px;
+    font-size: 0.825rem;
+}
+
+.gm-scrape-result {
+    background: rgba(217, 119, 6, 0.06);
+    border: 1px solid rgba(217, 119, 6, 0.25);
+    border-radius: var(--border-radius);
+    padding: 0.75rem 1rem;
+    margin-bottom: 0.75rem;
+}
+
+/* ---------- Planner Grid ---------- */
+.gm-planner-grid {
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--border-radius);
+    overflow: hidden;
+}
+
+.gm-planner-header,
+.gm-planner-row {
+    display: grid;
+    grid-template-columns: 140px repeat(3, 1fr);
+}
+
+.gm-planner-header {
+    background: var(--gray-50);
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--gray-500);
+}
+
+.gm-planner-header div,
+.gm-planner-day {
+    padding: 0.75rem 1rem;
+}
+
+.gm-planner-row {
+    border-top: 1px solid var(--gray-100);
+}
+
+.gm-planner-day {
+    font-weight: 600;
+    color: var(--gray-700);
+    font-size: 0.825rem;
+    display: flex;
+    align-items: center;
+}
+
+.gm-planner-cell {
+    padding: 0.6rem;
+    border-left: 1px solid var(--gray-100);
+    display: flex;
+    align-items: center;
+}
+
+.gm-planner-entry {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    background: rgba(37, 99, 235, 0.06);
+    border: 1px solid rgba(37, 99, 235, 0.2);
+    border-radius: 6px;
+    padding: 0.4rem 0.6rem;
+    font-size: 0.8rem;
+    color: var(--gray-800);
+}
+
+.gm-planner-add {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px dashed var(--gray-300);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--gray-400);
+    cursor: pointer;
+    transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.gm-planner-add:hover {
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+}
+
+/* ---------- Empty State ---------- */
+.gm-empty-state {
+    text-align: center;
+    padding: 4rem 2rem;
+    color: var(--gray-500);
+}
+
+.gm-empty-state i {
+    font-size: 4rem;
+    color: var(--gray-300);
+    margin-bottom: 1rem;
+    display: block;
+}
+
+.gm-empty-state h3 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--gray-600);
+    margin-bottom: 0.5rem;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 900px) {
+    .gm-planner-header,
+    .gm-planner-row {
+        grid-template-columns: 100px repeat(3, 1fr);
+    }
+}
+
+@media (max-width: 700px) {
+    .gm-card-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .gm-planner-header,
+    .gm-planner-row {
+        grid-template-columns: 1fr;
+    }
+
+    .gm-planner-header div:not(:first-child)::before,
+    .gm-planner-day {
+        font-weight: 700;
+    }
+}

--- a/Models/php/grocery_meal_api.php
+++ b/Models/php/grocery_meal_api.php
@@ -1,0 +1,749 @@
+<?php
+/**
+ * Grocery & Meal Planning API — backs Projects/Personal/00_004.
+ * Tables (gm_*) are created on first use so no separate migration step is needed.
+ */
+error_reporting(E_ALL);
+ini_set('display_errors', 0);
+ini_set('log_errors', 1);
+
+header('Content-Type: application/json');
+
+require_once __DIR__ . '/../../classes/Security.php';
+require_once __DIR__ . '/scrapers/ScraperFactory.php';
+
+function sendJsonResponse($data) {
+    echo json_encode($data, JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+Security::secureSession();
+if (empty($_SESSION['logged_in'])) {
+    sendJsonResponse(['success' => false, 'message' => 'Not authenticated']);
+}
+$currentUser = trim($_SESSION['username'] ?? '');
+session_write_close();
+
+// Support both GET (reads) and POST with a JSON or form body (writes)
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    $input  = $_GET;
+    $action = $_GET['action'] ?? '';
+} else {
+    $input = json_decode(file_get_contents('php://input'), true);
+    if (!is_array($input)) {
+        $input = $_POST;
+    }
+    $action = $input['action'] ?? '';
+}
+
+try {
+    require_once __DIR__ . '/../../Private/db_config.php';
+    $db  = new Database();
+    $pdo = $db->getConnection();
+
+    ensureSchema($pdo);
+
+    switch ($action) {
+        case 'get_stores':            getStores($pdo); break;
+
+        case 'get_products':          getProducts($pdo); break;
+        case 'save_product':          saveProduct($pdo, $input); break;
+        case 'delete_product':        deleteProduct($pdo, $input); break;
+
+        case 'get_prices':            getPrices($pdo, $input); break;
+        case 'save_price':            savePrice($pdo, $input, $currentUser); break;
+        case 'delete_price':          deletePrice($pdo, $input); break;
+        case 'scrape_price':          scrapePrice($pdo, $input); break;
+
+        case 'get_meals':             getMeals($pdo, $input); break;
+        case 'get_meal':              getMeal($pdo, $input); break;
+        case 'save_meal':             saveMeal($pdo, $input); break;
+        case 'delete_meal':           deleteMeal($pdo, $input); break;
+
+        case 'get_health_profile':    getHealthProfile($pdo, $currentUser); break;
+        case 'save_health_profile':   saveHealthProfile($pdo, $input, $currentUser); break;
+
+        case 'get_meal_plan':         getMealPlan($pdo, $input, $currentUser); break;
+        case 'save_meal_plan_entry':  saveMealPlanEntry($pdo, $input, $currentUser); break;
+        case 'delete_meal_plan_entry':deleteMealPlanEntry($pdo, $input, $currentUser); break;
+        case 'generate_meal_plan':    generateMealPlan($pdo, $input, $currentUser); break;
+
+        case 'get_shopping_list':     getShoppingList($pdo, $input, $currentUser); break;
+
+        default:
+            sendJsonResponse(['success' => false, 'message' => 'Invalid action']);
+    }
+} catch (Exception $e) {
+    error_log('Grocery/Meal API error: ' . $e->getMessage());
+    sendJsonResponse(['success' => false, 'message' => 'Server error occurred']);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Schema
+// ─────────────────────────────────────────────────────────────────────────
+
+function ensureSchema(PDO $pdo) {
+    $pdo->exec("CREATE TABLE IF NOT EXISTS gm_stores (
+        store_id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(100) NOT NULL UNIQUE,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB");
+
+    $pdo->exec("CREATE TABLE IF NOT EXISTS gm_products (
+        product_id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(150) NOT NULL,
+        category VARCHAR(80) NULL,
+        unit VARCHAR(30) NOT NULL DEFAULT 'each',
+        notes TEXT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE KEY uniq_product_name (name)
+    ) ENGINE=InnoDB");
+
+    $pdo->exec("CREATE TABLE IF NOT EXISTS gm_product_prices (
+        price_id INT AUTO_INCREMENT PRIMARY KEY,
+        product_id INT NOT NULL,
+        store_id INT NOT NULL,
+        price DECIMAL(8,2) NOT NULL,
+        observed_date DATE NOT NULL,
+        source ENUM('manual','scraped') NOT NULL DEFAULT 'manual',
+        needs_review TINYINT(1) NOT NULL DEFAULT 0,
+        raw_snippet VARCHAR(500) NULL,
+        created_by VARCHAR(100) NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        INDEX idx_product_store_date (product_id, store_id, observed_date),
+        CONSTRAINT fk_gm_price_product FOREIGN KEY (product_id) REFERENCES gm_products(product_id) ON DELETE CASCADE,
+        CONSTRAINT fk_gm_price_store FOREIGN KEY (store_id) REFERENCES gm_stores(store_id) ON DELETE CASCADE
+    ) ENGINE=InnoDB");
+
+    $pdo->exec("CREATE TABLE IF NOT EXISTS gm_meals (
+        meal_id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(150) NOT NULL,
+        meal_type ENUM('breakfast','lunch','dinner','snack') NOT NULL DEFAULT 'dinner',
+        servings INT NOT NULL DEFAULT 4,
+        calories INT NULL,
+        protein_g INT NULL,
+        carbs_g INT NULL,
+        fat_g INT NULL,
+        tags VARCHAR(300) NULL,
+        instructions TEXT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB");
+
+    $pdo->exec("CREATE TABLE IF NOT EXISTS gm_meal_ingredients (
+        ingredient_id INT AUTO_INCREMENT PRIMARY KEY,
+        meal_id INT NOT NULL,
+        product_id INT NOT NULL,
+        quantity DECIMAL(8,2) NOT NULL DEFAULT 1,
+        unit VARCHAR(30) NULL,
+        CONSTRAINT fk_gm_ingredient_meal FOREIGN KEY (meal_id) REFERENCES gm_meals(meal_id) ON DELETE CASCADE,
+        CONSTRAINT fk_gm_ingredient_product FOREIGN KEY (product_id) REFERENCES gm_products(product_id) ON DELETE CASCADE
+    ) ENGINE=InnoDB");
+
+    $pdo->exec("CREATE TABLE IF NOT EXISTS gm_meal_plan (
+        plan_id INT AUTO_INCREMENT PRIMARY KEY,
+        username VARCHAR(100) NOT NULL,
+        plan_date DATE NOT NULL,
+        meal_type ENUM('breakfast','lunch','dinner','snack') NOT NULL,
+        meal_id INT NOT NULL,
+        servings_planned INT NOT NULL DEFAULT 1,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        INDEX idx_username_date (username, plan_date),
+        CONSTRAINT fk_gm_plan_meal FOREIGN KEY (meal_id) REFERENCES gm_meals(meal_id) ON DELETE CASCADE
+    ) ENGINE=InnoDB");
+
+    $pdo->exec("CREATE TABLE IF NOT EXISTS gm_health_profile (
+        username VARCHAR(100) PRIMARY KEY,
+        calorie_target INT NULL,
+        protein_target_g INT NULL,
+        carbs_target_g INT NULL,
+        fat_target_g INT NULL,
+        allergies VARCHAR(300) NULL,
+        restrictions VARCHAR(300) NULL,
+        notes TEXT NULL,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB");
+
+    // Seed the three stores the user cares about (idempotent)
+    $stmt = $pdo->prepare("INSERT IGNORE INTO gm_stores (name) VALUES (:name)");
+    foreach (['HEB', 'Sprouts', 'Costco'] as $storeName) {
+        $stmt->execute([':name' => $storeName]);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Stores
+// ─────────────────────────────────────────────────────────────────────────
+
+function getStores(PDO $pdo) {
+    $stores = $pdo->query("SELECT * FROM gm_stores ORDER BY name")->fetchAll(PDO::FETCH_ASSOC);
+    sendJsonResponse(['success' => true, 'stores' => $stores]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Products
+// ─────────────────────────────────────────────────────────────────────────
+
+function getProducts(PDO $pdo) {
+    $products = $pdo->query("SELECT * FROM gm_products ORDER BY category, name")->fetchAll(PDO::FETCH_ASSOC);
+    sendJsonResponse(['success' => true, 'products' => $products]);
+}
+
+function saveProduct(PDO $pdo, array $input) {
+    $name = trim($input['name'] ?? '');
+    if ($name === '') {
+        sendJsonResponse(['success' => false, 'message' => 'Product name is required']);
+    }
+
+    $productId = (int) ($input['product_id'] ?? 0);
+    $category  = trim($input['category'] ?? '') ?: null;
+    $unit      = trim($input['unit'] ?? '') ?: 'each';
+    $notes     = trim($input['notes'] ?? '') ?: null;
+
+    if ($productId > 0) {
+        $stmt = $pdo->prepare(
+            "UPDATE gm_products SET name = :name, category = :category, unit = :unit, notes = :notes
+             WHERE product_id = :id"
+        );
+        $stmt->execute([':name' => $name, ':category' => $category, ':unit' => $unit, ':notes' => $notes, ':id' => $productId]);
+    } else {
+        $stmt = $pdo->prepare(
+            "INSERT INTO gm_products (name, category, unit, notes) VALUES (:name, :category, :unit, :notes)
+             ON DUPLICATE KEY UPDATE category = VALUES(category), unit = VALUES(unit), notes = VALUES(notes)"
+        );
+        $stmt->execute([':name' => $name, ':category' => $category, ':unit' => $unit, ':notes' => $notes]);
+        $productId = (int) $pdo->lastInsertId();
+        if ($productId === 0) {
+            $lookup = $pdo->prepare("SELECT product_id FROM gm_products WHERE name = :name");
+            $lookup->execute([':name' => $name]);
+            $productId = (int) $lookup->fetchColumn();
+        }
+    }
+
+    sendJsonResponse(['success' => true, 'product_id' => $productId]);
+}
+
+function deleteProduct(PDO $pdo, array $input) {
+    $productId = (int) ($input['product_id'] ?? 0);
+    if (!$productId) {
+        sendJsonResponse(['success' => false, 'message' => 'product_id is required']);
+    }
+    $pdo->prepare("DELETE FROM gm_products WHERE product_id = :id")->execute([':id' => $productId]);
+    sendJsonResponse(['success' => true]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Prices
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Latest observed price per store for a product, plus recent history. */
+function getPrices(PDO $pdo, array $input) {
+    $productId = (int) ($input['product_id'] ?? 0);
+
+    if ($productId) {
+        $latest = $pdo->prepare(
+            "SELECT pp.*, s.name AS store_name
+             FROM gm_product_prices pp
+             JOIN gm_stores s ON s.store_id = pp.store_id
+             WHERE pp.product_id = :pid
+             AND pp.price_id IN (
+                 SELECT MAX(price_id) FROM gm_product_prices WHERE product_id = :pid2 GROUP BY store_id
+             )
+             ORDER BY pp.price ASC"
+        );
+        $latest->execute([':pid' => $productId, ':pid2' => $productId]);
+
+        $history = $pdo->prepare(
+            "SELECT pp.*, s.name AS store_name
+             FROM gm_product_prices pp
+             JOIN gm_stores s ON s.store_id = pp.store_id
+             WHERE pp.product_id = :pid
+             ORDER BY pp.observed_date DESC, pp.price_id DESC
+             LIMIT 50"
+        );
+        $history->execute([':pid' => $productId]);
+
+        sendJsonResponse([
+            'success' => true,
+            'latest'  => $latest->fetchAll(PDO::FETCH_ASSOC),
+            'history' => $history->fetchAll(PDO::FETCH_ASSOC),
+        ]);
+    }
+
+    // No product filter: cheapest current price per product, across all products
+    $rows = $pdo->query(
+        "SELECT pp.product_id, p.name AS product_name, p.unit, pp.store_id, s.name AS store_name,
+                pp.price, pp.observed_date, pp.source, pp.needs_review
+         FROM gm_product_prices pp
+         JOIN gm_products p ON p.product_id = pp.product_id
+         JOIN gm_stores s ON s.store_id = pp.store_id
+         WHERE pp.price_id IN (
+             SELECT MAX(price_id) FROM gm_product_prices GROUP BY product_id, store_id
+         )
+         ORDER BY p.name, pp.price ASC"
+    )->fetchAll(PDO::FETCH_ASSOC);
+
+    sendJsonResponse(['success' => true, 'prices' => $rows]);
+}
+
+function savePrice(PDO $pdo, array $input, string $currentUser) {
+    $productId = (int) ($input['product_id'] ?? 0);
+    $storeId   = (int) ($input['store_id'] ?? 0);
+    $price     = $input['price'] ?? null;
+
+    if (!$productId || !$storeId || !is_numeric($price) || (float) $price < 0) {
+        sendJsonResponse(['success' => false, 'message' => 'product_id, store_id, and a non-negative price are required']);
+    }
+
+    $observedDate = trim($input['observed_date'] ?? '') ?: date('Y-m-d');
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $observedDate)) {
+        sendJsonResponse(['success' => false, 'message' => 'Invalid observed_date']);
+    }
+
+    $stmt = $pdo->prepare(
+        "INSERT INTO gm_product_prices (product_id, store_id, price, observed_date, source, needs_review, raw_snippet, created_by)
+         VALUES (:product_id, :store_id, :price, :observed_date, 'manual', 0, NULL, :created_by)"
+    );
+    $stmt->execute([
+        ':product_id'    => $productId,
+        ':store_id'      => $storeId,
+        ':price'         => (float) $price,
+        ':observed_date' => $observedDate,
+        ':created_by'    => $currentUser,
+    ]);
+
+    sendJsonResponse(['success' => true, 'price_id' => (int) $pdo->lastInsertId()]);
+}
+
+function deletePrice(PDO $pdo, array $input) {
+    $priceId = (int) ($input['price_id'] ?? 0);
+    if (!$priceId) {
+        sendJsonResponse(['success' => false, 'message' => 'price_id is required']);
+    }
+    $pdo->prepare("DELETE FROM gm_product_prices WHERE price_id = :id")->execute([':id' => $priceId]);
+    sendJsonResponse(['success' => true]);
+}
+
+/**
+ * Best-effort scrape: looks up a price via the store's scraper and returns
+ * it for review — it is NOT saved automatically. The UI should show the
+ * result with a clear "unverified" label and let the user save it via
+ * save_price (or discard it) after eyeballing it against the real store.
+ */
+function scrapePrice(PDO $pdo, array $input) {
+    $storeId     = (int) ($input['store_id'] ?? 0);
+    $productName = trim($input['product_name'] ?? '');
+
+    if (!$storeId || $productName === '') {
+        sendJsonResponse(['success' => false, 'message' => 'store_id and product_name are required']);
+    }
+
+    $storeStmt = $pdo->prepare("SELECT name FROM gm_stores WHERE store_id = :id");
+    $storeStmt->execute([':id' => $storeId]);
+    $storeName = $storeStmt->fetchColumn();
+    if (!$storeName) {
+        sendJsonResponse(['success' => false, 'message' => 'Unknown store']);
+    }
+
+    $scraper = ScraperFactory::forStore($storeName);
+    if (!$scraper) {
+        sendJsonResponse(['success' => false, 'message' => "No scraper available for $storeName"]);
+    }
+
+    $result = $scraper->lookupPrice($productName);
+    if ($result === null) {
+        sendJsonResponse([
+            'success' => false,
+            'message' => "Couldn't find a confident match at $storeName — enter the price manually.",
+        ]);
+    }
+
+    sendJsonResponse([
+        'success'      => true,
+        'needs_review' => true,
+        'store_id'     => $storeId,
+        'store_name'   => $storeName,
+        'price'        => $result['price'],
+        'matched_name' => $result['matched_name'],
+        'raw_snippet'  => $result['raw_snippet'],
+    ]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Meals
+// ─────────────────────────────────────────────────────────────────────────
+
+function getMeals(PDO $pdo, array $input) {
+    $mealType = trim($input['meal_type'] ?? '');
+    if ($mealType !== '') {
+        $stmt = $pdo->prepare("SELECT * FROM gm_meals WHERE meal_type = :type ORDER BY name");
+        $stmt->execute([':type' => $mealType]);
+        $meals = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    } else {
+        $meals = $pdo->query("SELECT * FROM gm_meals ORDER BY meal_type, name")->fetchAll(PDO::FETCH_ASSOC);
+    }
+    sendJsonResponse(['success' => true, 'meals' => $meals]);
+}
+
+function getMeal(PDO $pdo, array $input) {
+    $mealId = (int) ($input['meal_id'] ?? 0);
+    if (!$mealId) {
+        sendJsonResponse(['success' => false, 'message' => 'meal_id is required']);
+    }
+
+    $stmt = $pdo->prepare("SELECT * FROM gm_meals WHERE meal_id = :id");
+    $stmt->execute([':id' => $mealId]);
+    $meal = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$meal) {
+        sendJsonResponse(['success' => false, 'message' => 'Meal not found']);
+    }
+
+    $ingredientsStmt = $pdo->prepare(
+        "SELECT mi.*, p.name AS product_name, p.unit AS product_unit
+         FROM gm_meal_ingredients mi
+         JOIN gm_products p ON p.product_id = mi.product_id
+         WHERE mi.meal_id = :id
+         ORDER BY p.name"
+    );
+    $ingredientsStmt->execute([':id' => $mealId]);
+    $meal['ingredients'] = $ingredientsStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    sendJsonResponse(['success' => true, 'meal' => $meal]);
+}
+
+function saveMeal(PDO $pdo, array $input) {
+    $name = trim($input['name'] ?? '');
+    if ($name === '') {
+        sendJsonResponse(['success' => false, 'message' => 'Meal name is required']);
+    }
+
+    $mealId    = (int) ($input['meal_id'] ?? 0);
+    $mealType  = in_array($input['meal_type'] ?? '', ['breakfast', 'lunch', 'dinner', 'snack'], true)
+        ? $input['meal_type'] : 'dinner';
+    $servings  = max(1, (int) ($input['servings'] ?? 4));
+    $calories  = is_numeric($input['calories'] ?? null) ? (int) $input['calories'] : null;
+    $protein   = is_numeric($input['protein_g'] ?? null) ? (int) $input['protein_g'] : null;
+    $carbs     = is_numeric($input['carbs_g'] ?? null) ? (int) $input['carbs_g'] : null;
+    $fat       = is_numeric($input['fat_g'] ?? null) ? (int) $input['fat_g'] : null;
+    $tags      = trim($input['tags'] ?? '') ?: null;
+    $instructions = trim($input['instructions'] ?? '') ?: null;
+    $ingredients  = is_array($input['ingredients'] ?? null) ? $input['ingredients'] : [];
+
+    $pdo->beginTransaction();
+    try {
+        if ($mealId > 0) {
+            $stmt = $pdo->prepare(
+                "UPDATE gm_meals SET name = :name, meal_type = :type, servings = :servings, calories = :calories,
+                 protein_g = :protein, carbs_g = :carbs, fat_g = :fat, tags = :tags, instructions = :instructions
+                 WHERE meal_id = :id"
+            );
+            $stmt->execute([
+                ':name' => $name, ':type' => $mealType, ':servings' => $servings, ':calories' => $calories,
+                ':protein' => $protein, ':carbs' => $carbs, ':fat' => $fat, ':tags' => $tags,
+                ':instructions' => $instructions, ':id' => $mealId,
+            ]);
+            $pdo->prepare("DELETE FROM gm_meal_ingredients WHERE meal_id = :id")->execute([':id' => $mealId]);
+        } else {
+            $stmt = $pdo->prepare(
+                "INSERT INTO gm_meals (name, meal_type, servings, calories, protein_g, carbs_g, fat_g, tags, instructions)
+                 VALUES (:name, :type, :servings, :calories, :protein, :carbs, :fat, :tags, :instructions)"
+            );
+            $stmt->execute([
+                ':name' => $name, ':type' => $mealType, ':servings' => $servings, ':calories' => $calories,
+                ':protein' => $protein, ':carbs' => $carbs, ':fat' => $fat, ':tags' => $tags,
+                ':instructions' => $instructions,
+            ]);
+            $mealId = (int) $pdo->lastInsertId();
+        }
+
+        $ingredientStmt = $pdo->prepare(
+            "INSERT INTO gm_meal_ingredients (meal_id, product_id, quantity, unit) VALUES (:meal_id, :product_id, :quantity, :unit)"
+        );
+        foreach ($ingredients as $ingredient) {
+            $productId = (int) ($ingredient['product_id'] ?? 0);
+            if (!$productId) {
+                continue;
+            }
+            $ingredientStmt->execute([
+                ':meal_id'    => $mealId,
+                ':product_id' => $productId,
+                ':quantity'   => is_numeric($ingredient['quantity'] ?? null) ? (float) $ingredient['quantity'] : 1,
+                ':unit'       => trim($ingredient['unit'] ?? '') ?: null,
+            ]);
+        }
+
+        $pdo->commit();
+    } catch (Exception $e) {
+        $pdo->rollBack();
+        throw $e;
+    }
+
+    sendJsonResponse(['success' => true, 'meal_id' => $mealId]);
+}
+
+function deleteMeal(PDO $pdo, array $input) {
+    $mealId = (int) ($input['meal_id'] ?? 0);
+    if (!$mealId) {
+        sendJsonResponse(['success' => false, 'message' => 'meal_id is required']);
+    }
+    $pdo->prepare("DELETE FROM gm_meals WHERE meal_id = :id")->execute([':id' => $mealId]);
+    sendJsonResponse(['success' => true]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Health profile (manual entry — tailors meal plan generation)
+// ─────────────────────────────────────────────────────────────────────────
+
+function getHealthProfile(PDO $pdo, string $currentUser) {
+    $stmt = $pdo->prepare("SELECT * FROM gm_health_profile WHERE username = :username");
+    $stmt->execute([':username' => $currentUser]);
+    $profile = $stmt->fetch(PDO::FETCH_ASSOC);
+    sendJsonResponse(['success' => true, 'profile' => $profile ?: null]);
+}
+
+function saveHealthProfile(PDO $pdo, array $input, string $currentUser) {
+    $stmt = $pdo->prepare(
+        "INSERT INTO gm_health_profile (username, calorie_target, protein_target_g, carbs_target_g, fat_target_g, allergies, restrictions, notes)
+         VALUES (:username, :calorie, :protein, :carbs, :fat, :allergies, :restrictions, :notes)
+         ON DUPLICATE KEY UPDATE calorie_target = VALUES(calorie_target), protein_target_g = VALUES(protein_target_g),
+             carbs_target_g = VALUES(carbs_target_g), fat_target_g = VALUES(fat_target_g),
+             allergies = VALUES(allergies), restrictions = VALUES(restrictions), notes = VALUES(notes)"
+    );
+    $stmt->execute([
+        ':username'     => $currentUser,
+        ':calorie'      => is_numeric($input['calorie_target'] ?? null) ? (int) $input['calorie_target'] : null,
+        ':protein'      => is_numeric($input['protein_target_g'] ?? null) ? (int) $input['protein_target_g'] : null,
+        ':carbs'        => is_numeric($input['carbs_target_g'] ?? null) ? (int) $input['carbs_target_g'] : null,
+        ':fat'          => is_numeric($input['fat_target_g'] ?? null) ? (int) $input['fat_target_g'] : null,
+        ':allergies'    => trim($input['allergies'] ?? '') ?: null,
+        ':restrictions' => trim($input['restrictions'] ?? '') ?: null,
+        ':notes'        => trim($input['notes'] ?? '') ?: null,
+    ]);
+    sendJsonResponse(['success' => true]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Meal plan
+// ─────────────────────────────────────────────────────────────────────────
+
+function getMealPlan(PDO $pdo, array $input, string $currentUser) {
+    [$startDate, $endDate] = resolveDateRange($input);
+
+    $stmt = $pdo->prepare(
+        "SELECT mp.*, m.name AS meal_name, m.calories, m.protein_g, m.carbs_g, m.fat_g, m.tags
+         FROM gm_meal_plan mp
+         JOIN gm_meals m ON m.meal_id = mp.meal_id
+         WHERE mp.username = :username AND mp.plan_date BETWEEN :start AND :end
+         ORDER BY mp.plan_date, FIELD(mp.meal_type, 'breakfast','lunch','dinner','snack')"
+    );
+    $stmt->execute([':username' => $currentUser, ':start' => $startDate, ':end' => $endDate]);
+
+    sendJsonResponse([
+        'success'    => true,
+        'plan'       => $stmt->fetchAll(PDO::FETCH_ASSOC),
+        'start_date' => $startDate,
+        'end_date'   => $endDate,
+    ]);
+}
+
+function saveMealPlanEntry(PDO $pdo, array $input, string $currentUser) {
+    $planDate = trim($input['plan_date'] ?? '');
+    $mealType = trim($input['meal_type'] ?? '');
+    $mealId   = (int) ($input['meal_id'] ?? 0);
+    $servings = max(1, (int) ($input['servings_planned'] ?? 1));
+
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $planDate) || !in_array($mealType, ['breakfast', 'lunch', 'dinner', 'snack'], true) || !$mealId) {
+        sendJsonResponse(['success' => false, 'message' => 'plan_date, meal_type, and meal_id are required']);
+    }
+
+    $stmt = $pdo->prepare(
+        "INSERT INTO gm_meal_plan (username, plan_date, meal_type, meal_id, servings_planned)
+         VALUES (:username, :date, :type, :meal_id, :servings)"
+    );
+    $stmt->execute([
+        ':username' => $currentUser, ':date' => $planDate, ':type' => $mealType,
+        ':meal_id' => $mealId, ':servings' => $servings,
+    ]);
+
+    sendJsonResponse(['success' => true, 'plan_id' => (int) $pdo->lastInsertId()]);
+}
+
+function deleteMealPlanEntry(PDO $pdo, array $input, string $currentUser) {
+    $planId = (int) ($input['plan_id'] ?? 0);
+    if (!$planId) {
+        sendJsonResponse(['success' => false, 'message' => 'plan_id is required']);
+    }
+    $stmt = $pdo->prepare("DELETE FROM gm_meal_plan WHERE plan_id = :id AND username = :username");
+    $stmt->execute([':id' => $planId, ':username' => $currentUser]);
+    sendJsonResponse(['success' => true]);
+}
+
+/**
+ * Auto-fills empty slots in the date range with meals from the library,
+ * respecting the user's health profile (excludes meals tagged with a
+ * logged allergy/restriction) and avoiding repeats within the last 3 days.
+ * Slots that already have a plan entry are left untouched.
+ */
+function generateMealPlan(PDO $pdo, array $input, string $currentUser) {
+    [$startDate, $endDate] = resolveDateRange($input);
+    $slots = ['breakfast', 'lunch', 'dinner'];
+
+    $profileStmt = $pdo->prepare("SELECT * FROM gm_health_profile WHERE username = :username");
+    $profileStmt->execute([':username' => $currentUser]);
+    $profile = $profileStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+
+    $excludedTags = array_filter(array_map('trim', explode(',',
+        strtolower(($profile['allergies'] ?? '') . ',' . ($profile['restrictions'] ?? '')))));
+
+    $mealsByType = [];
+    foreach ($slots as $type) {
+        $stmt = $pdo->prepare("SELECT * FROM gm_meals WHERE meal_type = :type");
+        $stmt->execute([':type' => $type]);
+        $mealsByType[$type] = array_values(array_filter(
+            $stmt->fetchAll(PDO::FETCH_ASSOC),
+            function ($meal) use ($excludedTags) {
+                if (empty($excludedTags)) {
+                    return true;
+                }
+                $mealTags = array_map('trim', explode(',', strtolower($meal['tags'] ?? '')));
+                return !array_intersect($excludedTags, $mealTags);
+            }
+        ));
+    }
+
+    $existingStmt = $pdo->prepare(
+        "SELECT plan_date, meal_type, meal_id FROM gm_meal_plan WHERE username = :username AND plan_date BETWEEN :start AND :end"
+    );
+    $existingStmt->execute([':username' => $currentUser, ':start' => $startDate, ':end' => $endDate]);
+    $existing = $existingStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $filled = [];
+    $recentMealIds = [];
+    foreach ($existing as $row) {
+        $filled[$row['plan_date'] . '|' . $row['meal_type']] = true;
+        $recentMealIds[] = (int) $row['meal_id'];
+    }
+
+    $insertStmt = $pdo->prepare(
+        "INSERT INTO gm_meal_plan (username, plan_date, meal_type, meal_id, servings_planned)
+         VALUES (:username, :date, :type, :meal_id, 1)"
+    );
+
+    $inserted = 0;
+    $date = new DateTime($startDate);
+    $end  = new DateTime($endDate);
+    $calorieBudgetPerMeal = !empty($profile['calorie_target']) ? (int) ($profile['calorie_target'] / count($slots)) : null;
+
+    while ($date <= $end) {
+        $dateStr = $date->format('Y-m-d');
+        foreach ($slots as $type) {
+            if (isset($filled[$dateStr . '|' . $type]) || empty($mealsByType[$type])) {
+                continue;
+            }
+
+            $candidates = array_filter($mealsByType[$type], function ($meal) use ($recentMealIds) {
+                return !in_array((int) $meal['meal_id'], array_slice($recentMealIds, -3 * 3), true);
+            });
+            if (empty($candidates)) {
+                $candidates = $mealsByType[$type];
+            }
+
+            if ($calorieBudgetPerMeal) {
+                usort($candidates, function ($a, $b) use ($calorieBudgetPerMeal) {
+                    return abs(($a['calories'] ?? $calorieBudgetPerMeal) - $calorieBudgetPerMeal)
+                        <=> abs(($b['calories'] ?? $calorieBudgetPerMeal) - $calorieBudgetPerMeal);
+                });
+                $chosen = $candidates[array_rand(array_slice($candidates, 0, max(1, (int) (count($candidates) / 2)), true))];
+            } else {
+                $chosen = $candidates[array_rand($candidates)];
+            }
+
+            $insertStmt->execute([
+                ':username' => $currentUser, ':date' => $dateStr, ':type' => $type, ':meal_id' => $chosen['meal_id'],
+            ]);
+            $recentMealIds[] = (int) $chosen['meal_id'];
+            $inserted++;
+        }
+        $date->modify('+1 day');
+    }
+
+    sendJsonResponse(['success' => true, 'entries_created' => $inserted, 'start_date' => $startDate, 'end_date' => $endDate]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Shopping list
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Aggregates ingredient quantities across the meal plan for the date range,
+ * scaling by planned servings, and pairs each product with its cheapest
+ * currently-known store price.
+ */
+function getShoppingList(PDO $pdo, array $input, string $currentUser) {
+    [$startDate, $endDate] = resolveDateRange($input);
+
+    $stmt = $pdo->prepare(
+        "SELECT p.product_id, p.name AS product_name, p.unit, p.category,
+                SUM(mi.quantity * (mp.servings_planned / m.servings)) AS total_quantity
+         FROM gm_meal_plan mp
+         JOIN gm_meals m ON m.meal_id = mp.meal_id
+         JOIN gm_meal_ingredients mi ON mi.meal_id = m.meal_id
+         JOIN gm_products p ON p.product_id = mi.product_id
+         WHERE mp.username = :username AND mp.plan_date BETWEEN :start AND :end
+         GROUP BY p.product_id, p.name, p.unit, p.category
+         ORDER BY p.category, p.name"
+    );
+    $stmt->execute([':username' => $currentUser, ':start' => $startDate, ':end' => $endDate]);
+    $items = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $priceStmt = $pdo->prepare(
+        "SELECT pp.store_id, s.name AS store_name, pp.price
+         FROM gm_product_prices pp
+         JOIN gm_stores s ON s.store_id = pp.store_id
+         WHERE pp.product_id = :pid
+         AND pp.price_id IN (SELECT MAX(price_id) FROM gm_product_prices WHERE product_id = :pid2 GROUP BY store_id)
+         ORDER BY pp.price ASC"
+    );
+
+    $total = 0.0;
+    foreach ($items as &$item) {
+        $priceStmt->execute([':pid' => $item['product_id'], ':pid2' => $item['product_id']]);
+        $prices = $priceStmt->fetchAll(PDO::FETCH_ASSOC);
+        $item['store_prices'] = $prices;
+        $item['best_store']   = $prices[0]['store_name'] ?? null;
+        $item['best_price']   = $prices[0]['price'] ?? null;
+        $item['estimated_cost'] = $item['best_price'] !== null
+            ? round($item['best_price'] * (float) $item['total_quantity'], 2)
+            : null;
+        if ($item['estimated_cost'] !== null) {
+            $total += $item['estimated_cost'];
+        }
+    }
+    unset($item);
+
+    sendJsonResponse([
+        'success'        => true,
+        'items'          => $items,
+        'estimated_total'=> round($total, 2),
+        'start_date'     => $startDate,
+        'end_date'       => $endDate,
+    ]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+/** @return array{0: string, 1: string} */
+function resolveDateRange(array $input): array {
+    $startDate = trim($input['start_date'] ?? '');
+    $endDate   = trim($input['end_date'] ?? '');
+
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $startDate)) {
+        $startDate = date('Y-m-d', strtotime('monday this week'));
+    }
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $endDate)) {
+        $endDate = date('Y-m-d', strtotime($startDate . ' +6 days'));
+    }
+
+    return [$startDate, $endDate];
+}

--- a/Models/php/scrapers/BaseHttpScraper.php
+++ b/Models/php/scrapers/BaseHttpScraper.php
@@ -1,0 +1,134 @@
+<?php
+require_once __DIR__ . '/PriceScraperInterface.php';
+
+/**
+ * Best-effort scraper base.
+ *
+ * Fetches a store's public search results page and looks for schema.org
+ * Product/Offer JSON-LD blocks, which many retail sites embed for SEO even
+ * when the visible results grid is rendered client-side. This is a starting
+ * point, not a guarantee: HEB, Sprouts, and Costco all render search results
+ * with JavaScript, so a plain HTTP GET frequently will NOT see product data
+ * for a keyword search, only for a direct product page. Expect this to need
+ * per-store tuning (or a headless-browser fetch) once run against the real
+ * sites — this sandbox has no outbound access to verify the search URLs or
+ * markup. Every result should be shown to the user as "needs review" before
+ * it's trusted, and manual price entry remains the reliable path.
+ */
+abstract class BaseHttpScraper implements PriceScraperInterface {
+    /** sprintf template with a single %s for the URL-encoded search term. */
+    protected string $searchUrlTemplate = '';
+    protected int $timeoutSeconds = 8;
+    /** Minimum similar_text() match percentage to accept a candidate. */
+    protected int $minMatchPercent = 35;
+
+    public function lookupPrice(string $productName): ?array {
+        if ($this->searchUrlTemplate === '' || trim($productName) === '') {
+            return null;
+        }
+
+        $url = sprintf($this->searchUrlTemplate, rawurlencode($productName));
+        $html = $this->fetch($url);
+        if ($html === null) {
+            return null;
+        }
+
+        return $this->extractBestMatch($html, $productName);
+    }
+
+    protected function fetch(string $url): ?string {
+        if (!function_exists('curl_init')) {
+            return null;
+        }
+
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_MAXREDIRS      => 5,
+            CURLOPT_TIMEOUT        => $this->timeoutSeconds,
+            CURLOPT_USERAGENT      => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+                . '(KHTML, like Gecko) Chrome/124.0 Safari/537.36',
+            CURLOPT_HTTPHEADER     => ['Accept: text/html,application/xhtml+xml'],
+        ]);
+
+        $body  = curl_exec($ch);
+        $errno = curl_errno($ch);
+        curl_close($ch);
+
+        return ($errno === 0 && is_string($body) && $body !== '') ? $body : null;
+    }
+
+    protected function extractBestMatch(string $html, string $productName): ?array {
+        if (!preg_match_all(
+            '/<script[^>]*type=["\']application\/ld\+json["\'][^>]*>(.*?)<\/script>/is',
+            $html,
+            $matches
+        )) {
+            return null;
+        }
+
+        $needle = strtolower($productName);
+        $best   = null;
+
+        foreach ($matches[1] as $block) {
+            $data = json_decode(trim($block), true);
+            if ($data === null) {
+                continue;
+            }
+
+            foreach ($this->flattenNodes($data) as $node) {
+                if (!is_array($node) || ($node['@type'] ?? '') !== 'Product') {
+                    continue;
+                }
+
+                $price = $this->extractOfferPrice($node['offers'] ?? null);
+                if ($price === null) {
+                    continue;
+                }
+
+                $name = (string) ($node['name'] ?? '');
+                similar_text($needle, strtolower($name), $percent);
+
+                if ($best === null || $percent > $best['match_percent']) {
+                    $best = [
+                        'price'         => $price,
+                        'matched_name'  => $name,
+                        'raw_snippet'   => mb_substr($name . ' - $' . number_format($price, 2), 0, 200),
+                        'match_percent' => $percent,
+                    ];
+                }
+            }
+        }
+
+        if ($best === null || $best['match_percent'] < $this->minMatchPercent) {
+            return null;
+        }
+
+        unset($best['match_percent']);
+        return $best;
+    }
+
+    /** @param mixed $offers */
+    private function extractOfferPrice($offers): ?float {
+        if (is_array($offers) && isset($offers['price']) && is_numeric($offers['price'])) {
+            return (float) $offers['price'];
+        }
+        if (is_array($offers) && isset($offers[0]['price']) && is_numeric($offers[0]['price'])) {
+            return (float) $offers[0]['price'];
+        }
+        return null;
+    }
+
+    /** @param mixed $data @return array<int, mixed> */
+    private function flattenNodes($data): array {
+        if (!is_array($data)) {
+            return [];
+        }
+        if (isset($data['@graph']) && is_array($data['@graph'])) {
+            return array_values($data['@graph']);
+        }
+        $isList = array_keys($data) === range(0, count($data) - 1);
+        return $isList ? array_values($data) : [$data];
+    }
+}

--- a/Models/php/scrapers/CostcoScraper.php
+++ b/Models/php/scrapers/CostcoScraper.php
@@ -1,0 +1,13 @@
+<?php
+require_once __DIR__ . '/BaseHttpScraper.php';
+
+/**
+ * Best-effort price lookup against Costco's public catalog search results.
+ * Search URL unverified from this environment (no outbound access to
+ * costco.com) — confirm/adjust once run somewhere with real internet access.
+ * Costco also gates many prices behind membership login, so this will
+ * frequently return null even when the search page itself loads.
+ */
+class CostcoScraper extends BaseHttpScraper {
+    protected string $searchUrlTemplate = 'https://www.costco.com/CatalogSearch?dept=All&keyword=%s';
+}

--- a/Models/php/scrapers/HebScraper.php
+++ b/Models/php/scrapers/HebScraper.php
@@ -1,0 +1,11 @@
+<?php
+require_once __DIR__ . '/BaseHttpScraper.php';
+
+/**
+ * Best-effort price lookup against HEB's public search results.
+ * Search URL unverified from this environment (no outbound access to
+ * heb.com) — confirm/adjust once run somewhere with real internet access.
+ */
+class HebScraper extends BaseHttpScraper {
+    protected string $searchUrlTemplate = 'https://www.heb.com/search/?q=%s';
+}

--- a/Models/php/scrapers/PriceScraperInterface.php
+++ b/Models/php/scrapers/PriceScraperInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+interface PriceScraperInterface {
+    /**
+     * Best-effort lookup of a product's price by name.
+     * Returns ['price' => float, 'matched_name' => string, 'raw_snippet' => string] on a
+     * confident match, or null when nothing usable was found. Never throws — callers treat
+     * null as "fall back to manual entry".
+     */
+    public function lookupPrice(string $productName): ?array;
+}

--- a/Models/php/scrapers/ScraperFactory.php
+++ b/Models/php/scrapers/ScraperFactory.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/PriceScraperInterface.php';
+require_once __DIR__ . '/HebScraper.php';
+require_once __DIR__ . '/SproutsScraper.php';
+require_once __DIR__ . '/CostcoScraper.php';
+
+class ScraperFactory {
+    private static array $scrapers = [
+        'heb'     => HebScraper::class,
+        'sprouts' => SproutsScraper::class,
+        'costco'  => CostcoScraper::class,
+    ];
+
+    public static function forStore(string $storeName): ?PriceScraperInterface {
+        $class = self::$scrapers[strtolower(trim($storeName))] ?? null;
+        return $class ? new $class() : null;
+    }
+
+    /** @return string[] */
+    public static function supportedStores(): array {
+        return array_keys(self::$scrapers);
+    }
+}

--- a/Models/php/scrapers/SproutsScraper.php
+++ b/Models/php/scrapers/SproutsScraper.php
@@ -1,0 +1,11 @@
+<?php
+require_once __DIR__ . '/BaseHttpScraper.php';
+
+/**
+ * Best-effort price lookup against Sprouts Farmers Market's public search results.
+ * Search URL unverified from this environment (no outbound access to
+ * sprouts.com) — confirm/adjust once run somewhere with real internet access.
+ */
+class SproutsScraper extends BaseHttpScraper {
+    protected string $searchUrlTemplate = 'https://www.sprouts.com/search?q=%s';
+}

--- a/Projects/Personal/00_004/dashboard.php
+++ b/Projects/Personal/00_004/dashboard.php
@@ -1,0 +1,1033 @@
+<?php
+require_once '../../../classes/Security.php';
+Security::secureSession();
+if (empty($_SESSION['logged_in']) || !$_SESSION['logged_in']) {
+    header('Location: ../../../login.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Grocery &amp; Meal Planner</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js"></script>
+    <link rel="stylesheet" href="../../../Models/css/survey_projects_notes.css">
+    <link rel="stylesheet" href="../../../Models/css/grocery_meal.css">
+</head>
+<body>
+
+    <div class="container">
+        <button class="mobile-toggle" id="mobileToggle"><i class="fas fa-bars"></i></button>
+        <div class="sidebar" id="sidebar">
+            <button class="toggle-btn" id="toggleBtn"><i class="fas fa-chevron-left"></i></button>
+            <div class="sidebar-header">
+                <h1><i class="fas fa-basket-shopping"></i> Grocery &amp; Meals</h1>
+                <p>Weekly meal &amp; shopping planner</p>
+            </div>
+
+            <nav class="sidebar-nav">
+                <a href="#" class="nav-item active" onclick="switchTab('overview', this); return false;" data-tab="overview">
+                    <i class="fas fa-gauge-high"></i> Overview
+                </a>
+                <a href="#" class="nav-item" onclick="switchTab('meals', this); return false;" data-tab="meals">
+                    <i class="fas fa-utensils"></i> Meals
+                </a>
+                <a href="#" class="nav-item" onclick="switchTab('products', this); return false;" data-tab="products">
+                    <i class="fas fa-carrot"></i> Products &amp; Prices
+                </a>
+                <a href="#" class="nav-item" onclick="switchTab('planner', this); return false;" data-tab="planner">
+                    <i class="fas fa-calendar-week"></i> Meal Plan
+                </a>
+                <a href="#" class="nav-item" onclick="switchTab('shopping', this); return false;" data-tab="shopping">
+                    <i class="fas fa-cart-shopping"></i> Shopping List
+                </a>
+                <a href="#" class="nav-item" onclick="switchTab('health', this); return false;" data-tab="health">
+                    <i class="fas fa-heart-pulse"></i> Health Profile
+                </a>
+            </nav>
+        </div>
+    </div>
+
+    <div class="main-content">
+        <div class="top-bar">
+            <div class="top-bar-left">
+                <button class="mobile-menu-button" onclick="toggleSidebar()"><i class="fas fa-bars"></i></button>
+                <div>
+                    <h2 id="tabTitle">Overview</h2>
+                    <p id="tabSubtitle">This week at a glance</p>
+                </div>
+            </div>
+            <div class="top-bar-right" id="topBarActions"></div>
+        </div>
+
+        <div class="content-area">
+
+            <!-- ============ OVERVIEW ============ -->
+            <div class="tab-panel active" id="tab-overview">
+                <div class="gm-stat-grid" id="overviewStats"></div>
+                <div class="gm-panel">
+                    <h3><i class="fas fa-calendar-week"></i> This week's plan</h3>
+                    <div id="overviewPlan" class="gm-empty-inline">Loading...</div>
+                </div>
+            </div>
+
+            <!-- ============ MEALS ============ -->
+            <div class="tab-panel" id="tab-meals">
+                <div class="gm-filter-bar">
+                    <select id="mealTypeFilter" onchange="loadMeals()">
+                        <option value="">All meal types</option>
+                        <option value="breakfast">Breakfast</option>
+                        <option value="lunch">Lunch</option>
+                        <option value="dinner">Dinner</option>
+                        <option value="snack">Snack</option>
+                    </select>
+                </div>
+                <div id="mealsContainer" class="gm-card-grid"></div>
+            </div>
+
+            <!-- ============ PRODUCTS & PRICES ============ -->
+            <div class="tab-panel" id="tab-products">
+                <div id="productsContainer"></div>
+            </div>
+
+            <!-- ============ MEAL PLAN ============ -->
+            <div class="tab-panel" id="tab-planner">
+                <div class="gm-filter-bar">
+                    <button class="btn btn-secondary btn-sm" onclick="changeWeek(-7)"><i class="fas fa-chevron-left"></i></button>
+                    <span id="plannerWeekLabel" class="gm-week-label"></span>
+                    <button class="btn btn-secondary btn-sm" onclick="changeWeek(7)"><i class="fas fa-chevron-right"></i></button>
+                </div>
+                <div id="plannerGrid" class="gm-planner-grid"></div>
+            </div>
+
+            <!-- ============ SHOPPING LIST ============ -->
+            <div class="tab-panel" id="tab-shopping">
+                <div class="gm-filter-bar">
+                    <span id="shoppingWeekLabel" class="gm-week-label"></span>
+                </div>
+                <div id="shoppingContainer"></div>
+            </div>
+
+            <!-- ============ HEALTH PROFILE ============ -->
+            <div class="tab-panel" id="tab-health">
+                <div class="gm-panel" style="max-width: 640px;">
+                    <h3><i class="fas fa-heart-pulse"></i> Targets &amp; restrictions</h3>
+                    <p class="gm-hint">Entered manually. Used to filter meal suggestions (allergies/restrictions) and to size portions during auto-generate (calorie target).</p>
+                    <form id="healthForm" onsubmit="return false;">
+                        <div class="form-grid" style="grid-template-columns: 1fr 1fr 1fr; margin-bottom: 1rem;">
+                            <div class="form-group">
+                                <label class="form-label">Calorie target / day</label>
+                                <input type="number" class="form-input" id="hpCalories" min="0" placeholder="2200">
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">Protein target (g)</label>
+                                <input type="number" class="form-input" id="hpProtein" min="0" placeholder="150">
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">Carbs target (g)</label>
+                                <input type="number" class="form-input" id="hpCarbs" min="0" placeholder="220">
+                            </div>
+                        </div>
+                        <div class="form-grid" style="grid-template-columns: 1fr; margin-bottom: 1rem;">
+                            <div class="form-group">
+                                <label class="form-label">Fat target (g)</label>
+                                <input type="number" class="form-input" id="hpFat" min="0" placeholder="70">
+                            </div>
+                        </div>
+                        <div class="form-group" style="margin-bottom: 1rem;">
+                            <label class="form-label">Allergies <span class="gm-hint-inline">(comma-separated tags, matched against meal tags)</span></label>
+                            <input type="text" class="form-input" id="hpAllergies" placeholder="peanuts, shellfish">
+                        </div>
+                        <div class="form-group" style="margin-bottom: 1rem;">
+                            <label class="form-label">Dietary restrictions</label>
+                            <input type="text" class="form-input" id="hpRestrictions" placeholder="vegetarian, low-sodium">
+                        </div>
+                        <div class="form-group" style="margin-bottom: 1rem;">
+                            <label class="form-label">Notes <span class="gm-hint-inline">(e.g. biomarker flags from Function Health — no automated import yet, paste relevant notes here)</span></label>
+                            <textarea class="form-input" id="hpNotes" rows="3" placeholder="e.g. elevated LDL - prefer lower saturated fat meals"></textarea>
+                        </div>
+                        <button type="button" class="btn btn-primary" onclick="saveHealthProfile()"><i class="fas fa-save"></i> Save profile</button>
+                    </form>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+    <!-- ============ MEAL MODAL ============ -->
+    <div class="checklist-modal" id="mealModal">
+        <div class="checklist-modal-content" style="max-width: 640px; max-height: 90vh;">
+            <div class="checklist-modal-header">
+                <div class="checklist-modal-header-top">
+                    <h3><i class="fas fa-utensils"></i> <span id="mealModalTitle">Add Meal</span></h3>
+                    <button class="checklist-modal-close" onclick="closeModal('mealModal')"><i class="fas fa-times"></i></button>
+                </div>
+            </div>
+            <div class="checklist-modal-body" style="padding: 1.5rem;">
+                <form id="mealForm" onsubmit="return false;">
+                    <input type="hidden" id="editMealId" value="">
+                    <div class="form-group" style="margin-bottom: 1rem;">
+                        <label class="form-label">Meal name <span style="color: var(--danger-color);">*</span></label>
+                        <input type="text" class="form-input" id="mealName" placeholder="Sheet-pan chicken fajitas" required>
+                    </div>
+                    <div class="form-grid" style="grid-template-columns: 1fr 1fr; margin-bottom: 1rem;">
+                        <div class="form-group">
+                            <label class="form-label">Type</label>
+                            <select class="form-input" id="mealType">
+                                <option value="breakfast">Breakfast</option>
+                                <option value="lunch">Lunch</option>
+                                <option value="dinner" selected>Dinner</option>
+                                <option value="snack">Snack</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Servings</label>
+                            <input type="number" class="form-input" id="mealServings" min="1" value="4">
+                        </div>
+                    </div>
+                    <div class="form-grid" style="grid-template-columns: 1fr 1fr 1fr; margin-bottom: 1rem;">
+                        <div class="form-group">
+                            <label class="form-label">Calories</label>
+                            <input type="number" class="form-input" id="mealCalories" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Protein (g)</label>
+                            <input type="number" class="form-input" id="mealProtein" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Carbs (g)</label>
+                            <input type="number" class="form-input" id="mealCarbs" min="0">
+                        </div>
+                    </div>
+                    <div class="form-grid" style="grid-template-columns: 1fr; margin-bottom: 1rem;">
+                        <div class="form-group">
+                            <label class="form-label">Fat (g)</label>
+                            <input type="number" class="form-input" id="mealFat" min="0">
+                        </div>
+                    </div>
+                    <div class="form-group" style="margin-bottom: 1rem;">
+                        <label class="form-label">Tags <span class="gm-hint-inline">(comma-separated, e.g. vegetarian, gluten-free)</span></label>
+                        <input type="text" class="form-input" id="mealTags" placeholder="vegetarian, quick">
+                    </div>
+                    <div class="form-group" style="margin-bottom: 1rem;">
+                        <label class="form-label">Instructions</label>
+                        <textarea class="form-input" id="mealInstructions" rows="3"></textarea>
+                    </div>
+
+                    <div class="form-group" style="margin-bottom: 0.5rem;">
+                        <label class="form-label">Ingredients</label>
+                    </div>
+                    <div id="ingredientRows"></div>
+                    <button type="button" class="btn btn-secondary btn-sm" onclick="addIngredientRow()" style="margin-bottom: 1rem;">
+                        <i class="fas fa-plus"></i> Add ingredient
+                    </button>
+
+                    <div style="display:flex; justify-content:flex-end; gap:0.5rem; margin-top: 1rem;">
+                        <button type="button" class="btn btn-secondary" onclick="closeModal('mealModal')">Cancel</button>
+                        <button type="button" class="btn btn-primary" onclick="saveMeal()"><i class="fas fa-save"></i> Save meal</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============ PRODUCT MODAL ============ -->
+    <div class="checklist-modal" id="productModal">
+        <div class="checklist-modal-content" style="max-width: 480px;">
+            <div class="checklist-modal-header">
+                <div class="checklist-modal-header-top">
+                    <h3><i class="fas fa-carrot"></i> <span id="productModalTitle">Add Product</span></h3>
+                    <button class="checklist-modal-close" onclick="closeModal('productModal')"><i class="fas fa-times"></i></button>
+                </div>
+            </div>
+            <div class="checklist-modal-body" style="padding: 1.5rem;">
+                <form id="productForm" onsubmit="return false;">
+                    <input type="hidden" id="editProductId" value="">
+                    <div class="form-group" style="margin-bottom: 1rem;">
+                        <label class="form-label">Product name <span style="color: var(--danger-color);">*</span></label>
+                        <input type="text" class="form-input" id="productName" placeholder="Boneless chicken thighs" required>
+                    </div>
+                    <div class="form-grid" style="grid-template-columns: 1fr 1fr; margin-bottom: 1rem;">
+                        <div class="form-group">
+                            <label class="form-label">Category</label>
+                            <input type="text" class="form-input" id="productCategory" placeholder="Meat">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Unit</label>
+                            <input type="text" class="form-input" id="productUnit" placeholder="lb" value="each">
+                        </div>
+                    </div>
+                    <div class="form-group" style="margin-bottom: 1rem;">
+                        <label class="form-label">Notes</label>
+                        <textarea class="form-input" id="productNotes" rows="2"></textarea>
+                    </div>
+                    <div style="display:flex; justify-content:flex-end; gap:0.5rem;">
+                        <button type="button" class="btn btn-secondary" onclick="closeModal('productModal')">Cancel</button>
+                        <button type="button" class="btn btn-primary" onclick="saveProduct()"><i class="fas fa-save"></i> Save product</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============ PRODUCT PRICE DETAIL MODAL ============ -->
+    <div class="checklist-modal" id="priceModal">
+        <div class="checklist-modal-content" style="max-width: 640px; max-height: 85vh;">
+            <div class="checklist-modal-header">
+                <div class="checklist-modal-header-top">
+                    <h3><i class="fas fa-tags"></i> <span id="priceModalTitle">Prices</span></h3>
+                    <button class="checklist-modal-close" onclick="closeModal('priceModal')"><i class="fas fa-times"></i></button>
+                </div>
+            </div>
+            <div class="checklist-modal-body" style="padding: 1.5rem;">
+                <div id="priceLatest" class="gm-price-latest"></div>
+
+                <h4 class="gm-subhead">Add a manual price</h4>
+                <div class="gm-inline-form">
+                    <select id="priceStoreSelect"></select>
+                    <input type="number" id="priceValue" step="0.01" min="0" placeholder="Price ($)">
+                    <input type="date" id="priceDate">
+                    <button class="btn btn-primary btn-sm" onclick="saveManualPrice()"><i class="fas fa-plus"></i> Add</button>
+                </div>
+
+                <h4 class="gm-subhead">Best-effort store lookup <span class="gm-hint-inline">(unverified — always confirm before saving)</span></h4>
+                <div class="gm-inline-form" id="scrapeControls"></div>
+                <div id="scrapeResult"></div>
+
+                <h4 class="gm-subhead">Price history</h4>
+                <div id="priceHistory"></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============ PLAN ENTRY MODAL ============ -->
+    <div class="checklist-modal" id="planEntryModal">
+        <div class="checklist-modal-content" style="max-width: 420px;">
+            <div class="checklist-modal-header">
+                <div class="checklist-modal-header-top">
+                    <h3><i class="fas fa-calendar-plus"></i> <span id="planEntryTitle">Add meal</span></h3>
+                    <button class="checklist-modal-close" onclick="closeModal('planEntryModal')"><i class="fas fa-times"></i></button>
+                </div>
+            </div>
+            <div class="checklist-modal-body" style="padding: 1.5rem;">
+                <input type="hidden" id="planEntryDate">
+                <input type="hidden" id="planEntryType">
+                <div class="form-group" style="margin-bottom: 1rem;">
+                    <label class="form-label">Meal</label>
+                    <select class="form-input" id="planEntryMealSelect"></select>
+                </div>
+                <div class="form-group" style="margin-bottom: 1rem;">
+                    <label class="form-label">Servings planned</label>
+                    <input type="number" class="form-input" id="planEntryServings" min="1" value="1">
+                </div>
+                <div style="display:flex; justify-content:flex-end; gap:0.5rem;">
+                    <button type="button" class="btn btn-secondary" onclick="closeModal('planEntryModal')">Cancel</button>
+                    <button type="button" class="btn btn-primary" onclick="savePlanEntry()"><i class="fas fa-save"></i> Add to plan</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="toast" class="toast">
+        <div class="toast-content">
+            <i class="fas fa-check-circle toast-icon"></i>
+            <span id="toastMessage">Saved</span>
+        </div>
+    </div>
+
+    <script>
+        const API_URL = '../../../Models/php/grocery_meal_api.php';
+
+        let allProducts = [];
+        let allMeals = [];
+        let allStores = [];
+        let currentProductId = null;
+        let weekStart = mondayOf(new Date());
+
+        document.addEventListener('DOMContentLoaded', function () {
+            setupSidebar();
+            switchTab('overview', document.querySelector('[data-tab="overview"]'));
+            loadStores().then(() => {
+                loadProducts();
+                loadMeals().then(loadOverview);
+                loadPlanner();
+                loadShoppingList();
+            });
+            loadHealthProfile();
+        });
+
+        function setupSidebar() {
+            const sidebar = document.getElementById('sidebar');
+            const toggleButton = document.getElementById('toggleBtn');
+            const mainContent = document.querySelector('.main-content');
+            const mobileToggle = document.getElementById('mobileToggle');
+            toggleButton.addEventListener('click', () => {
+                sidebar.classList.toggle('collapsed');
+                mainContent.classList.toggle('collapsed');
+            });
+            mobileToggle.addEventListener('click', () => sidebar.classList.toggle('collapsed'));
+        }
+        function toggleSidebar() { document.getElementById('sidebar').classList.toggle('open'); }
+
+        // ============================================================
+        // TABS
+        // ============================================================
+        const tabMeta = {
+            overview: { title: 'Overview', subtitle: 'This week at a glance', actions: '' },
+            meals: {
+                title: 'Meals', subtitle: 'Your meal library',
+                actions: `<button class="btn btn-primary" onclick="openMealModal()"><i class="fas fa-plus"></i> Add Meal</button>`
+            },
+            products: {
+                title: 'Products & Prices', subtitle: 'Track prices across HEB, Sprouts, and Costco',
+                actions: `<button class="btn btn-primary" onclick="openProductModal()"><i class="fas fa-plus"></i> Add Product</button>`
+            },
+            planner: {
+                title: 'Meal Plan', subtitle: 'Assign meals to each day of the week',
+                actions: `<button class="btn btn-primary" onclick="generateWeek()"><i class="fas fa-wand-magic-sparkles"></i> Auto-Generate Week</button>`
+            },
+            shopping: { title: 'Shopping List', subtitle: 'Aggregated ingredients with cheapest store per item', actions: '' },
+            health: { title: 'Health Profile', subtitle: 'Targets and restrictions that tailor your meal plan', actions: '' }
+        };
+
+        function switchTab(tab, el) {
+            document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+            document.querySelectorAll('.nav-item').forEach(n => n.classList.remove('active'));
+            const panel = document.getElementById('tab-' + tab);
+            if (panel) panel.classList.add('active');
+            if (el) el.classList.add('active');
+            const meta = tabMeta[tab] || {};
+            document.getElementById('tabTitle').textContent = meta.title || '';
+            document.getElementById('tabSubtitle').textContent = meta.subtitle || '';
+            document.getElementById('topBarActions').innerHTML = meta.actions || '';
+        }
+
+        // ============================================================
+        // STORES
+        // ============================================================
+        async function loadStores() {
+            try {
+                const res = await fetch(`${API_URL}?action=get_stores`);
+                const data = await res.json();
+                if (data.success) allStores = data.stores || [];
+            } catch (e) { console.error(e); }
+        }
+
+        // ============================================================
+        // OVERVIEW
+        // ============================================================
+        async function loadOverview() {
+            document.getElementById('overviewStats').innerHTML = `
+                <div class="gm-stat-card"><i class="fas fa-utensils"></i><div><strong>${allMeals.length}</strong><span>Meals in library</span></div></div>
+                <div class="gm-stat-card"><i class="fas fa-carrot"></i><div><strong>${allProducts.length}</strong><span>Products tracked</span></div></div>
+            `;
+            try {
+                const res = await fetch(`${API_URL}?action=get_meal_plan&start_date=${fmtDate(weekStart)}&end_date=${fmtDate(addDays(weekStart, 6))}`);
+                const data = await res.json();
+                const container = document.getElementById('overviewPlan');
+                if (data.success && data.plan.length) {
+                    container.innerHTML = renderPlanSummary(data.plan);
+                } else {
+                    container.innerHTML = `<p class="gm-hint">No meals planned this week yet. Head to <strong>Meal Plan</strong> to add some.</p>`;
+                }
+            } catch (e) { console.error(e); }
+        }
+
+        function renderPlanSummary(plan) {
+            const byDate = {};
+            plan.forEach(p => { (byDate[p.plan_date] = byDate[p.plan_date] || []).push(p); });
+            return Object.keys(byDate).sort().map(date => `
+                <div class="gm-plan-summary-row">
+                    <strong>${formatDayLabel(date)}</strong>
+                    <span>${byDate[date].map(p => `${capitalize(p.meal_type)}: ${escapeHtml(p.meal_name)}`).join(' &middot; ')}</span>
+                </div>
+            `).join('');
+        }
+
+        // ============================================================
+        // MEALS
+        // ============================================================
+        async function loadMeals() {
+            const type = document.getElementById('mealTypeFilter').value;
+            try {
+                const res = await fetch(`${API_URL}?action=get_meals${type ? '&meal_type=' + type : ''}`);
+                const data = await res.json();
+                if (data.success) {
+                    allMeals = data.meals || [];
+                    renderMeals();
+                } else {
+                    showToast(data.message || 'Error loading meals', 'error');
+                }
+            } catch (e) { console.error(e); showToast('Network error loading meals', 'error'); }
+        }
+
+        function renderMeals() {
+            const container = document.getElementById('mealsContainer');
+            if (!allMeals.length) {
+                container.innerHTML = `<div class="gm-empty-state"><i class="fas fa-utensils"></i><h3>No meals yet</h3><p>Add your first meal to start building the library.</p></div>`;
+                return;
+            }
+            container.innerHTML = allMeals.map(m => `
+                <div class="gm-card">
+                    <div class="gm-card-header">
+                        <span class="gm-type-badge">${capitalize(m.meal_type)}</span>
+                        <div class="gm-card-actions">
+                            <button class="btn btn-xs btn-secondary" onclick="openMealModal(${m.meal_id})"><i class="fas fa-pen"></i></button>
+                            <button class="btn btn-xs btn-secondary" onclick="deleteMeal(${m.meal_id})"><i class="fas fa-trash"></i></button>
+                        </div>
+                    </div>
+                    <div class="gm-card-name">${escapeHtml(m.name)}</div>
+                    <div class="gm-card-macros">
+                        ${m.calories ? `<span><i class="fas fa-fire"></i> ${m.calories} cal</span>` : ''}
+                        ${m.protein_g ? `<span>P ${m.protein_g}g</span>` : ''}
+                        ${m.carbs_g ? `<span>C ${m.carbs_g}g</span>` : ''}
+                        ${m.fat_g ? `<span>F ${m.fat_g}g</span>` : ''}
+                    </div>
+                    ${m.tags ? `<div class="gm-tags">${m.tags.split(',').map(t => `<span class="gm-tag">${escapeHtml(t.trim())}</span>`).join('')}</div>` : ''}
+                </div>
+            `).join('');
+        }
+
+        async function openMealModal(mealId) {
+            document.getElementById('mealForm').reset();
+            document.getElementById('editMealId').value = '';
+            document.getElementById('ingredientRows').innerHTML = '';
+            document.getElementById('mealModalTitle').textContent = mealId ? 'Edit Meal' : 'Add Meal';
+
+            if (mealId) {
+                const res = await fetch(`${API_URL}?action=get_meal&meal_id=${mealId}`);
+                const data = await res.json();
+                if (!data.success) { showToast(data.message || 'Meal not found', 'error'); return; }
+                const meal = data.meal;
+                document.getElementById('editMealId').value = meal.meal_id;
+                document.getElementById('mealName').value = meal.name;
+                document.getElementById('mealType').value = meal.meal_type;
+                document.getElementById('mealServings').value = meal.servings;
+                document.getElementById('mealCalories').value = meal.calories || '';
+                document.getElementById('mealProtein').value = meal.protein_g || '';
+                document.getElementById('mealCarbs').value = meal.carbs_g || '';
+                document.getElementById('mealFat').value = meal.fat_g || '';
+                document.getElementById('mealTags').value = meal.tags || '';
+                document.getElementById('mealInstructions').value = meal.instructions || '';
+                (meal.ingredients || []).forEach(ing => addIngredientRow(ing.product_id, ing.quantity, ing.unit));
+            } else {
+                addIngredientRow();
+            }
+            openModal('mealModal');
+        }
+
+        function addIngredientRow(productId, quantity, unit) {
+            const row = document.createElement('div');
+            row.className = 'gm-ingredient-row';
+            const options = allProducts.map(p => `<option value="${p.product_id}" ${productId == p.product_id ? 'selected' : ''}>${escapeHtml(p.name)}</option>`).join('');
+            row.innerHTML = `
+                <select class="gm-ingredient-product">${options || '<option value="">No products yet — add some first</option>'}</select>
+                <input type="number" class="gm-ingredient-qty" step="0.01" min="0" value="${quantity || 1}" placeholder="Qty">
+                <input type="text" class="gm-ingredient-unit" value="${escapeHtml(unit || '')}" placeholder="unit">
+                <button type="button" class="btn btn-xs btn-secondary" onclick="this.parentElement.remove()"><i class="fas fa-times"></i></button>
+            `;
+            document.getElementById('ingredientRows').appendChild(row);
+        }
+
+        async function saveMeal() {
+            const name = document.getElementById('mealName').value.trim();
+            if (!name) { showToast('Meal name is required', 'error'); return; }
+
+            const ingredients = Array.from(document.querySelectorAll('#ingredientRows .gm-ingredient-row')).map(row => ({
+                product_id: parseInt(row.querySelector('.gm-ingredient-product').value) || 0,
+                quantity: parseFloat(row.querySelector('.gm-ingredient-qty').value) || 1,
+                unit: row.querySelector('.gm-ingredient-unit').value.trim()
+            })).filter(i => i.product_id);
+
+            const payload = {
+                action: 'save_meal',
+                meal_id: document.getElementById('editMealId').value || undefined,
+                name,
+                meal_type: document.getElementById('mealType').value,
+                servings: document.getElementById('mealServings').value,
+                calories: document.getElementById('mealCalories').value,
+                protein_g: document.getElementById('mealProtein').value,
+                carbs_g: document.getElementById('mealCarbs').value,
+                fat_g: document.getElementById('mealFat').value,
+                tags: document.getElementById('mealTags').value.trim(),
+                instructions: document.getElementById('mealInstructions').value.trim(),
+                ingredients
+            };
+
+            try {
+                const res = await fetch(API_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+                const data = await res.json();
+                if (data.success) {
+                    showToast('Meal saved');
+                    closeModal('mealModal');
+                    loadMeals();
+                } else {
+                    showToast(data.message || 'Error saving meal', 'error');
+                }
+            } catch (e) { console.error(e); showToast('Network error saving meal', 'error'); }
+        }
+
+        async function deleteMeal(id) {
+            if (!confirm('Delete this meal? This also removes it from any meal plan entries.')) return;
+            try {
+                const res = await fetch(API_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'delete_meal', meal_id: id }) });
+                const data = await res.json();
+                if (data.success) { showToast('Meal deleted'); loadMeals(); } else { showToast(data.message || 'Error deleting meal', 'error'); }
+            } catch (e) { console.error(e); showToast('Network error deleting meal', 'error'); }
+        }
+
+        // ============================================================
+        // PRODUCTS & PRICES
+        // ============================================================
+        async function loadProducts() {
+            try {
+                const [prodRes, priceRes] = await Promise.all([
+                    fetch(`${API_URL}?action=get_products`),
+                    fetch(`${API_URL}?action=get_prices`)
+                ]);
+                const prodData = await prodRes.json();
+                const priceData = await priceRes.json();
+                if (prodData.success) allProducts = prodData.products || [];
+
+                const cheapest = {};
+                if (priceData.success) {
+                    (priceData.prices || []).forEach(row => {
+                        if (!cheapest[row.product_id] || parseFloat(row.price) < parseFloat(cheapest[row.product_id].price)) cheapest[row.product_id] = row;
+                    });
+                }
+                renderProducts(cheapest);
+            } catch (e) { console.error(e); showToast('Network error loading products', 'error'); }
+        }
+
+        function renderProducts(cheapest) {
+            const container = document.getElementById('productsContainer');
+            if (!allProducts.length) {
+                container.innerHTML = `<div class="gm-empty-state"><i class="fas fa-carrot"></i><h3>No products yet</h3><p>Add products to start tracking prices and building meals.</p></div>`;
+                return;
+            }
+            container.innerHTML = `
+                <table class="gm-table">
+                    <thead><tr><th>Product</th><th>Category</th><th>Unit</th><th>Best known price</th><th></th></tr></thead>
+                    <tbody>
+                        ${allProducts.map(p => {
+                            const c = cheapest[p.product_id];
+                            return `
+                            <tr>
+                                <td>${escapeHtml(p.name)}</td>
+                                <td>${escapeHtml(p.category || '—')}</td>
+                                <td>${escapeHtml(p.unit)}</td>
+                                <td>${c ? `$${Number(c.price).toFixed(2)} <span class="gm-hint-inline">at ${escapeHtml(c.store_name)}${c.needs_review ? ' (unverified)' : ''}</span>` : '<span class="gm-hint-inline">No prices yet</span>'}</td>
+                                <td class="gm-table-actions">
+                                    <button class="btn btn-xs btn-secondary" onclick="openPriceModal(${p.product_id})"><i class="fas fa-tags"></i> Prices</button>
+                                    <button class="btn btn-xs btn-secondary" onclick="openProductModal(${p.product_id})"><i class="fas fa-pen"></i></button>
+                                    <button class="btn btn-xs btn-secondary" onclick="deleteProduct(${p.product_id})"><i class="fas fa-trash"></i></button>
+                                </td>
+                            </tr>`;
+                        }).join('')}
+                    </tbody>
+                </table>
+            `;
+        }
+
+        function openProductModal(productId) {
+            document.getElementById('productForm').reset();
+            document.getElementById('editProductId').value = '';
+            document.getElementById('productModalTitle').textContent = productId ? 'Edit Product' : 'Add Product';
+            if (productId) {
+                const p = allProducts.find(x => x.product_id == productId);
+                if (p) {
+                    document.getElementById('editProductId').value = p.product_id;
+                    document.getElementById('productName').value = p.name;
+                    document.getElementById('productCategory').value = p.category || '';
+                    document.getElementById('productUnit').value = p.unit;
+                    document.getElementById('productNotes').value = p.notes || '';
+                }
+            } else {
+                document.getElementById('productUnit').value = 'each';
+            }
+            openModal('productModal');
+        }
+
+        async function saveProduct() {
+            const name = document.getElementById('productName').value.trim();
+            if (!name) { showToast('Product name is required', 'error'); return; }
+            const payload = {
+                action: 'save_product',
+                product_id: document.getElementById('editProductId').value || undefined,
+                name,
+                category: document.getElementById('productCategory').value.trim(),
+                unit: document.getElementById('productUnit').value.trim() || 'each',
+                notes: document.getElementById('productNotes').value.trim()
+            };
+            try {
+                const res = await fetch(API_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+                const data = await res.json();
+                if (data.success) { showToast('Product saved'); closeModal('productModal'); loadProducts(); }
+                else showToast(data.message || 'Error saving product', 'error');
+            } catch (e) { console.error(e); showToast('Network error saving product', 'error'); }
+        }
+
+        async function deleteProduct(id) {
+            if (!confirm('Delete this product? This also removes its prices and any meal ingredient links.')) return;
+            try {
+                const res = await fetch(API_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'delete_product', product_id: id }) });
+                const data = await res.json();
+                if (data.success) { showToast('Product deleted'); loadProducts(); } else showToast(data.message || 'Error deleting product', 'error');
+            } catch (e) { console.error(e); showToast('Network error deleting product', 'error'); }
+        }
+
+        async function openPriceModal(productId) {
+            currentProductId = productId;
+            const p = allProducts.find(x => x.product_id == productId);
+            document.getElementById('priceModalTitle').textContent = p ? `Prices — ${p.name}` : 'Prices';
+            document.getElementById('priceDate').value = fmtDate(new Date());
+
+            document.getElementById('priceStoreSelect').innerHTML = allStores.map(s => `<option value="${s.store_id}">${escapeHtml(s.name)}</option>`).join('');
+            document.getElementById('scrapeControls').innerHTML = allStores.map(s =>
+                `<button class="btn btn-secondary btn-sm" onclick="scrapePriceFor(${s.store_id}, '${escapeHtml(s.name)}')"><i class="fas fa-magnifying-glass"></i> Check ${escapeHtml(s.name)}</button>`
+            ).join('');
+            document.getElementById('scrapeResult').innerHTML = '';
+
+            await refreshPriceModal();
+            openModal('priceModal');
+        }
+
+        async function refreshPriceModal() {
+            try {
+                const res = await fetch(`${API_URL}?action=get_prices&product_id=${currentProductId}`);
+                const data = await res.json();
+                if (!data.success) return;
+
+                document.getElementById('priceLatest').innerHTML = data.latest.length
+                    ? `<div class="gm-latest-grid">${data.latest.map(r => `
+                        <div class="gm-latest-card">
+                            <strong>${escapeHtml(r.store_name)}</strong>
+                            <span>$${Number(r.price).toFixed(2)}</span>
+                            <small>${r.observed_date}${r.needs_review ? ' &middot; unverified' : ''}</small>
+                        </div>`).join('')}</div>`
+                    : '<p class="gm-hint">No prices recorded yet.</p>';
+
+                document.getElementById('priceHistory').innerHTML = data.history.length
+                    ? `<table class="gm-table"><thead><tr><th>Store</th><th>Price</th><th>Date</th><th>Source</th><th></th></tr></thead><tbody>
+                        ${data.history.map(r => `
+                        <tr>
+                            <td>${escapeHtml(r.store_name)}</td>
+                            <td>$${Number(r.price).toFixed(2)}</td>
+                            <td>${r.observed_date}</td>
+                            <td>${r.source}${r.needs_review ? ' (unverified)' : ''}</td>
+                            <td><button class="btn btn-xs btn-secondary" onclick="deletePriceEntry(${r.price_id})"><i class="fas fa-trash"></i></button></td>
+                        </tr>`).join('')}
+                    </tbody></table>`
+                    : '<p class="gm-hint">No history yet.</p>';
+            } catch (e) { console.error(e); }
+        }
+
+        async function saveManualPrice() {
+            const storeId = document.getElementById('priceStoreSelect').value;
+            const price = document.getElementById('priceValue').value;
+            const date = document.getElementById('priceDate').value;
+            if (!price || isNaN(price)) { showToast('Enter a valid price', 'error'); return; }
+            try {
+                const res = await fetch(API_URL, {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'save_price', product_id: currentProductId, store_id: storeId, price, observed_date: date })
+                });
+                const data = await res.json();
+                if (data.success) {
+                    showToast('Price added');
+                    document.getElementById('priceValue').value = '';
+                    refreshPriceModal();
+                    loadProducts();
+                } else showToast(data.message || 'Error adding price', 'error');
+            } catch (e) { console.error(e); showToast('Network error adding price', 'error'); }
+        }
+
+        async function deletePriceEntry(priceId) {
+            if (!confirm('Delete this price entry?')) return;
+            try {
+                const res = await fetch(API_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'delete_price', price_id: priceId }) });
+                const data = await res.json();
+                if (data.success) { refreshPriceModal(); loadProducts(); } else showToast(data.message || 'Error deleting price', 'error');
+            } catch (e) { console.error(e); }
+        }
+
+        async function scrapePriceFor(storeId, storeName) {
+            const p = allProducts.find(x => x.product_id == currentProductId);
+            const resultBox = document.getElementById('scrapeResult');
+            resultBox.innerHTML = `<p class="gm-hint">Checking ${escapeHtml(storeName)}...</p>`;
+            try {
+                const res = await fetch(API_URL, {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'scrape_price', store_id: storeId, product_name: p ? p.name : '' })
+                });
+                const data = await res.json();
+                if (data.success) {
+                    resultBox.innerHTML = `
+                        <div class="gm-scrape-result">
+                            <p><strong>${escapeHtml(data.store_name)}:</strong> $${Number(data.price).toFixed(2)} — matched "${escapeHtml(data.matched_name)}"</p>
+                            <p class="gm-hint-inline">Unverified — double check against the store before trusting it.</p>
+                            <button class="btn btn-sm btn-primary" onclick="confirmScrapedPrice(${data.store_id}, ${data.price})">
+                                <i class="fas fa-check"></i> Looks right, save it
+                            </button>
+                        </div>`;
+                } else {
+                    resultBox.innerHTML = `<p class="gm-hint">${escapeHtml(data.message || 'No match found')}</p>`;
+                }
+            } catch (e) { console.error(e); resultBox.innerHTML = `<p class="gm-hint">Network error checking price.</p>`; }
+        }
+
+        async function confirmScrapedPrice(storeId, price) {
+            try {
+                const res = await fetch(API_URL, {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'save_price', product_id: currentProductId, store_id: storeId, price, observed_date: fmtDate(new Date()) })
+                });
+                const data = await res.json();
+                if (data.success) { showToast('Price saved'); document.getElementById('scrapeResult').innerHTML = ''; refreshPriceModal(); loadProducts(); }
+                else showToast(data.message || 'Error saving price', 'error');
+            } catch (e) { console.error(e); showToast('Network error saving price', 'error'); }
+        }
+
+        // ============================================================
+        // MEAL PLAN (PLANNER)
+        // ============================================================
+        function changeWeek(deltaDays) {
+            weekStart = addDays(weekStart, deltaDays);
+            loadPlanner();
+            loadShoppingList();
+            loadOverview();
+        }
+
+        async function loadPlanner() {
+            const start = fmtDate(weekStart), end = fmtDate(addDays(weekStart, 6));
+            document.getElementById('plannerWeekLabel').textContent = `${start} to ${end}`;
+            try {
+                const res = await fetch(`${API_URL}?action=get_meal_plan&start_date=${start}&end_date=${end}`);
+                const data = await res.json();
+                if (data.success) renderPlanner(data.plan);
+                else showToast(data.message || 'Error loading plan', 'error');
+            } catch (e) { console.error(e); showToast('Network error loading plan', 'error'); }
+        }
+
+        function renderPlanner(plan) {
+            const slots = ['breakfast', 'lunch', 'dinner'];
+            const byKey = {};
+            plan.forEach(p => { byKey[p.plan_date + '|' + p.meal_type] = p; });
+
+            let html = '<div class="gm-planner-header"><div></div>' + slots.map(s => `<div>${capitalize(s)}</div>`).join('') + '</div>';
+            for (let i = 0; i < 7; i++) {
+                const date = addDays(weekStart, i);
+                const dateStr = fmtDate(date);
+                html += `<div class="gm-planner-row"><div class="gm-planner-day">${formatDayLabel(dateStr)}</div>`;
+                slots.forEach(type => {
+                    const entry = byKey[dateStr + '|' + type];
+                    html += `<div class="gm-planner-cell">`;
+                    if (entry) {
+                        html += `<div class="gm-planner-entry">
+                            <span>${escapeHtml(entry.meal_name)}</span>
+                            <button class="btn btn-xs btn-secondary" onclick="deletePlanEntry(${entry.plan_id})"><i class="fas fa-times"></i></button>
+                        </div>`;
+                    } else {
+                        html += `<button class="gm-planner-add" onclick="openPlanEntryModal('${dateStr}', '${type}')"><i class="fas fa-plus"></i></button>`;
+                    }
+                    html += `</div>`;
+                });
+                html += `</div>`;
+            }
+            document.getElementById('plannerGrid').innerHTML = html;
+        }
+
+        function openPlanEntryModal(dateStr, type) {
+            document.getElementById('planEntryDate').value = dateStr;
+            document.getElementById('planEntryType').value = type;
+            document.getElementById('planEntryTitle').textContent = `Add ${capitalize(type)} — ${formatDayLabel(dateStr)}`;
+            document.getElementById('planEntryServings').value = 1;
+            const options = allMeals.filter(m => m.meal_type === type);
+            document.getElementById('planEntryMealSelect').innerHTML = options.length
+                ? options.map(m => `<option value="${m.meal_id}">${escapeHtml(m.name)}</option>`).join('')
+                : `<option value="">No ${type} meals in your library yet</option>`;
+            openModal('planEntryModal');
+        }
+
+        async function savePlanEntry() {
+            const mealId = document.getElementById('planEntryMealSelect').value;
+            if (!mealId) { showToast('Add a meal of this type first', 'error'); return; }
+            const payload = {
+                action: 'save_meal_plan_entry',
+                plan_date: document.getElementById('planEntryDate').value,
+                meal_type: document.getElementById('planEntryType').value,
+                meal_id: mealId,
+                servings_planned: document.getElementById('planEntryServings').value
+            };
+            try {
+                const res = await fetch(API_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+                const data = await res.json();
+                if (data.success) { showToast('Added to plan'); closeModal('planEntryModal'); loadPlanner(); loadShoppingList(); loadOverview(); }
+                else showToast(data.message || 'Error adding to plan', 'error');
+            } catch (e) { console.error(e); showToast('Network error updating plan', 'error'); }
+        }
+
+        async function deletePlanEntry(planId) {
+            if (!confirm('Remove this meal from the plan?')) return;
+            try {
+                const res = await fetch(API_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action: 'delete_meal_plan_entry', plan_id: planId }) });
+                const data = await res.json();
+                if (data.success) { loadPlanner(); loadShoppingList(); loadOverview(); } else showToast(data.message || 'Error removing entry', 'error');
+            } catch (e) { console.error(e); }
+        }
+
+        async function generateWeek() {
+            const start = fmtDate(weekStart), end = fmtDate(addDays(weekStart, 6));
+            try {
+                const res = await fetch(API_URL, {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'generate_meal_plan', start_date: start, end_date: end })
+                });
+                const data = await res.json();
+                if (data.success) {
+                    showToast(`Filled ${data.entries_created} empty slot(s)`);
+                    loadPlanner(); loadShoppingList(); loadOverview();
+                } else showToast(data.message || 'Error generating plan', 'error');
+            } catch (e) { console.error(e); showToast('Network error generating plan', 'error'); }
+        }
+
+        // ============================================================
+        // SHOPPING LIST
+        // ============================================================
+        async function loadShoppingList() {
+            const start = fmtDate(weekStart), end = fmtDate(addDays(weekStart, 6));
+            document.getElementById('shoppingWeekLabel').textContent = `${start} to ${end}`;
+            try {
+                const res = await fetch(`${API_URL}?action=get_shopping_list&start_date=${start}&end_date=${end}`);
+                const data = await res.json();
+                if (data.success) renderShoppingList(data);
+                else showToast(data.message || 'Error loading shopping list', 'error');
+            } catch (e) { console.error(e); showToast('Network error loading shopping list', 'error'); }
+        }
+
+        function renderShoppingList(data) {
+            const container = document.getElementById('shoppingContainer');
+            if (!data.items.length) {
+                container.innerHTML = `<div class="gm-empty-state"><i class="fas fa-cart-shopping"></i><h3>Nothing planned</h3><p>Add meals to this week's plan to generate a shopping list.</p></div>`;
+                return;
+            }
+            container.innerHTML = `
+                <table class="gm-table">
+                    <thead><tr><th>Item</th><th>Qty</th><th>Best store</th><th>Est. cost</th></tr></thead>
+                    <tbody>
+                        ${data.items.map(i => `
+                        <tr>
+                            <td>${escapeHtml(i.product_name)}</td>
+                            <td>${Number(i.total_quantity).toFixed(2)} ${escapeHtml(i.unit)}</td>
+                            <td>${i.best_store ? escapeHtml(i.best_store) : '<span class="gm-hint-inline">No price yet</span>'}</td>
+                            <td>${i.estimated_cost !== null ? '$' + Number(i.estimated_cost).toFixed(2) : '—'}</td>
+                        </tr>`).join('')}
+                    </tbody>
+                    <tfoot><tr><td colspan="3"><strong>Estimated total</strong></td><td><strong>$${Number(data.estimated_total).toFixed(2)}</strong></td></tr></tfoot>
+                </table>
+            `;
+        }
+
+        // ============================================================
+        // HEALTH PROFILE
+        // ============================================================
+        async function loadHealthProfile() {
+            try {
+                const res = await fetch(`${API_URL}?action=get_health_profile`);
+                const data = await res.json();
+                if (data.success && data.profile) {
+                    document.getElementById('hpCalories').value = data.profile.calorie_target || '';
+                    document.getElementById('hpProtein').value = data.profile.protein_target_g || '';
+                    document.getElementById('hpCarbs').value = data.profile.carbs_target_g || '';
+                    document.getElementById('hpFat').value = data.profile.fat_target_g || '';
+                    document.getElementById('hpAllergies').value = data.profile.allergies || '';
+                    document.getElementById('hpRestrictions').value = data.profile.restrictions || '';
+                    document.getElementById('hpNotes').value = data.profile.notes || '';
+                }
+            } catch (e) { console.error(e); }
+        }
+
+        async function saveHealthProfile() {
+            const payload = {
+                action: 'save_health_profile',
+                calorie_target: document.getElementById('hpCalories').value,
+                protein_target_g: document.getElementById('hpProtein').value,
+                carbs_target_g: document.getElementById('hpCarbs').value,
+                fat_target_g: document.getElementById('hpFat').value,
+                allergies: document.getElementById('hpAllergies').value.trim(),
+                restrictions: document.getElementById('hpRestrictions').value.trim(),
+                notes: document.getElementById('hpNotes').value.trim()
+            };
+            try {
+                const res = await fetch(API_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+                const data = await res.json();
+                if (data.success) showToast('Health profile saved'); else showToast(data.message || 'Error saving profile', 'error');
+            } catch (e) { console.error(e); showToast('Network error saving profile', 'error'); }
+        }
+
+        // ============================================================
+        // HELPERS
+        // ============================================================
+        function openModal(id) { document.getElementById(id).classList.add('active'); }
+        function closeModal(id) { document.getElementById(id).classList.remove('active'); }
+
+        function showToast(message, type = 'success') {
+            const toast = document.getElementById('toast');
+            const toastMessage = document.getElementById('toastMessage');
+            const toastIcon = document.querySelector('.toast-icon');
+            toastMessage.textContent = message;
+            if (type === 'error') {
+                toastIcon.className = 'fas fa-exclamation-circle toast-icon';
+                toast.style.borderLeftColor = 'var(--danger-color)';
+                toastIcon.style.color = 'var(--danger-color)';
+            } else {
+                toastIcon.className = 'fas fa-check-circle toast-icon';
+                toast.style.borderLeftColor = 'var(--success-color)';
+                toastIcon.style.color = 'var(--success-color)';
+            }
+            toast.classList.add('show');
+            setTimeout(() => toast.classList.remove('show'), 3500);
+        }
+
+        function escapeHtml(text) {
+            if (text === null || text === undefined) return '';
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        function capitalize(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1) : ''; }
+
+        function mondayOf(date) {
+            const d = new Date(date);
+            const day = d.getDay();
+            const diff = (day === 0 ? -6 : 1) - day;
+            d.setDate(d.getDate() + diff);
+            d.setHours(0, 0, 0, 0);
+            return d;
+        }
+
+        function addDays(date, days) {
+            const d = new Date(date);
+            d.setDate(d.getDate() + days);
+            return d;
+        }
+
+        function fmtDate(date) {
+            const y = date.getFullYear(), m = String(date.getMonth() + 1).padStart(2, '0'), d = String(date.getDate()).padStart(2, '0');
+            return `${y}-${m}-${d}`;
+        }
+
+        function formatDayLabel(dateStr) {
+            const d = new Date(dateStr + 'T00:00:00');
+            return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+        }
+
+        document.addEventListener('click', function (e) {
+            if (e.target.classList.contains('checklist-modal')) e.target.classList.remove('active');
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Adds a self-contained PHP/MySQL app (matching the existing CartoCesna
project pattern) for weekly grocery and meal planning:

- gm_* schema (products, meals + ingredients, per-store price history,
  meal plan, health profile) auto-created on first API call
- Manual price entry per store (HEB/Sprouts/Costco) plus a best-effort
  JSON-LD scraper module as a starting point, always surfaced as
  "needs review" rather than trusted automatically
- Meal plan auto-generate that respects a manually-entered health
  profile (calorie target, allergies/restrictions); Function Health has
  no public API, so health data is manual-entry only for now
- Shopping list that aggregates the week's planned meals and picks the
  cheapest known store per product

Not yet done: registering the project row in personal_projects (needs
live DB access this session doesn't have) and verifying/tuning the
scraper search URLs against the real store sites (also no outbound
network access here).